### PR TITLE
feat: mdots pushのcommonコピーを実装する

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mogurastore/mdots/config"
+	"github.com/mogurastore/mdots/sync"
+)
+
+func main() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(run(os.Args[1:], cwd))
+}
+
+func run(args []string, cwd string) int {
+	if len(args) != 1 || args[0] != "push" {
+		fmt.Fprintln(os.Stderr, "usage: mdots push")
+		return 1
+	}
+	if err := runPush(cwd); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+// runPush は common の Entry のみを Store から dest へコピーする。
+func runPush(cwd string) error {
+	store, err := config.FindStore(cwd)
+	if err != nil {
+		return err
+	}
+	cfg, err := config.Load(filepath.Join(store, "mdots.yaml"))
+	if err != nil {
+		return err
+	}
+	entries := config.FilterByTarget(cfg.Entries, "")
+	return sync.Push(store, entries)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Seam: CLIコマンド境界 (mdots push)
+// 実FS上の Store/dest を用い、end-to-end の外部挙動のみを検証する。
+func TestPushEndToEnd(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("set number\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := run([]string{"push"}, store); code != 0 {
+		t.Fatalf("run(push) exit = %d, want 0", code)
+	}
+	got, err := os.ReadFile(filepath.Join(home, ".vimrc"))
+	if err != nil {
+		t.Fatalf("dest read error: %v", err)
+	}
+	if string(got) != "set number\n" {
+		t.Errorf("dest content = %q, want %q", got, "set number\n")
+	}
+}
+
+func TestPushFromSubdirFindsStore(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(store, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := run([]string{"push"}, sub); code != 0 {
+		t.Fatalf("run(push) from subdir exit = %d, want 0", code)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".vimrc")); err != nil {
+		t.Errorf("dest not created from subdir: %v", err)
+	}
+}
+
+func TestPushOnlyCommonEntries(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(store, "common.conf"), []byte("common\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store, "win.conf"), []byte("win\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n" +
+		"  - src: common.conf\n    dest: ~/.common.conf\n" +
+		"  - src: win.conf\n    dest: ~/.win.conf\n    target: win\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := run([]string{"push"}, store); code != 0 {
+		t.Fatalf("run(push) exit = %d, want 0", code)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".common.conf")); err != nil {
+		t.Errorf("common Entry should be copied: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".win.conf")); err == nil {
+		t.Error("win Entry should NOT be copied without --target")
+	}
+}
+
+func TestPushWithoutStoreFails(t *testing.T) {
+	empty := t.TempDir()
+	if code := run([]string{"push"}, empty); code == 0 {
+		t.Error("run(push) without Store: exit = 0, want non-zero")
+	}
+}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -1,0 +1,66 @@
+package sync
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/mogurastore/mdots/config"
+)
+
+// Push は Store の src を dest へファイルコピーする。
+// Entry の src は Store 相対、dest は ~ 展開される配置先パス。
+// 親ディレクトリは mkdir -p、パーミッションは元ファイルに追従、上書きは無確認。
+// src/dest がディレクトリの場合はエラーになる。src 不在もエラーで中断する。
+func Push(storeRoot string, entries []config.Entry) error {
+	for _, e := range entries {
+		srcPath := filepath.Join(storeRoot, e.Src)
+		destPath, err := config.ExpandDest(e.Dest)
+		if err != nil {
+			return fmt.Errorf("push %s: dest expand: %w", e.Src, err)
+		}
+		if err := copyFile(srcPath, destPath); err != nil {
+			return fmt.Errorf("push %s: %w", e.Src, err)
+		}
+	}
+	return nil
+}
+
+func copyFile(srcPath, destPath string) error {
+	srcInfo, err := os.Stat(srcPath)
+	if err != nil {
+		return err
+	}
+	if srcInfo.IsDir() {
+		return fmt.Errorf("src is a directory: %s", srcPath)
+	}
+	if destInfo, err := os.Stat(destPath); err == nil && destInfo.IsDir() {
+		return fmt.Errorf("dest is a directory: %s", destPath)
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return err
+	}
+
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	dst, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		_ = dst.Close()
+		return err
+	}
+	if err := dst.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(destPath, srcInfo.Mode().Perm()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -1,0 +1,164 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mogurastore/mdots/config"
+)
+
+// Seam: sync パッケージ公開境界 (push)
+// Store/src → dest のファイルコピーを t.TempDir() の実FSで検証する。
+func TestPushCopiesStoreToDest(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	srcPath := filepath.Join(store, "vimrc")
+	if err := os.WriteFile(srcPath, []byte("set number\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(home, ".vimrc")
+	entries := []config.Entry{{Src: "vimrc", Dest: dest}}
+
+	if err := Push(store, entries); err != nil {
+		t.Fatalf("Push error: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("dest read error: %v", err)
+	}
+	if string(got) != "set number\n" {
+		t.Errorf("dest content = %q, want %q", got, "set number\n")
+	}
+}
+
+func TestPushCreatesParentDirs(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	srcPath := filepath.Join(store, "wezterm.lua")
+	if err := os.WriteFile(srcPath, []byte("return {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(destRoot, ".config", "wezterm", "wezterm.lua")
+	entries := []config.Entry{{Src: "wezterm.lua", Dest: dest}}
+
+	if err := Push(store, entries); err != nil {
+		t.Fatalf("Push error: %v", err)
+	}
+	if _, err := os.Stat(dest); err != nil {
+		t.Errorf("dest not created: %v", err)
+	}
+}
+
+func TestPushExpandsHomeDest(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	srcPath := filepath.Join(store, "bashrc")
+	if err := os.WriteFile(srcPath, []byte("export X=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "bashrc", Dest: "~/.bashrc"}}
+
+	if err := Push(store, entries); err != nil {
+		t.Fatalf("Push error: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(home, ".bashrc"))
+	if err != nil {
+		t.Fatalf("expanded dest read error: %v", err)
+	}
+	if string(got) != "export X=1\n" {
+		t.Errorf("dest content = %q, want %q", got, "export X=1\n")
+	}
+}
+
+func TestPushRejectsDirectories(t *testing.T) {
+	t.Run("srcがディレクトリはエラー", func(t *testing.T) {
+		store := t.TempDir()
+		destRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(store, "mydir"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		entries := []config.Entry{{Src: "mydir", Dest: filepath.Join(destRoot, "mydir")}}
+		if err := Push(store, entries); err == nil {
+			t.Error("エラー expected, got nil")
+		}
+	})
+
+	t.Run("destがディレクトリはエラー", func(t *testing.T) {
+		store := t.TempDir()
+		destRoot := t.TempDir()
+		if err := os.WriteFile(filepath.Join(store, "a"), []byte("a"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		destDir := filepath.Join(destRoot, "existing")
+		if err := os.MkdirAll(destDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		entries := []config.Entry{{Src: "a", Dest: destDir}}
+		if err := Push(store, entries); err == nil {
+			t.Error("エラー expected, got nil")
+		}
+	})
+}
+
+func TestPushOverwritesExisting(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(store, "a"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(destRoot, "a")
+	if err := os.WriteFile(dest, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "a", Dest: dest}}
+
+	if err := Push(store, entries); err != nil {
+		t.Fatalf("Push error: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Errorf("dest content = %q, want %q", got, "new")
+	}
+}
+
+func TestPushPreservesPermission(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	srcPath := filepath.Join(store, "run.sh")
+	if err := os.WriteFile(srcPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(destRoot, "run.sh")
+	entries := []config.Entry{{Src: "run.sh", Dest: dest}}
+
+	if err := Push(store, entries); err != nil {
+		t.Fatalf("Push error: %v", err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("dest perm = %o, want 755", info.Mode().Perm())
+	}
+}
+
+func TestPushMissingSrcIsError(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+	entries := []config.Entry{{Src: "missing", Dest: filepath.Join(destRoot, "missing")}}
+	if err := Push(store, entries); err == nil {
+		t.Error("エラー expected, got nil")
+	}
+}


### PR DESCRIPTION
Closes #3

- sync.Push を追加: Store相対src → ~展開dest へコピー、mkdir -p、パーミッション追従、上書き無確認、src/destディレクトリはエラー
- main.go に mdots push を追加: FindStore親探索 → Load → FilterByTarget commonのみ → sync.Push、余剰引数はusageエラー
- 結合テスト: sync 7件 + CLI 4件 (t.TempDir実FS)
- go vet / go test ... / go build 確認済み