### PR TITLE
chore: opencode.jsonにGoコマンドの実行許可を追加

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "go test *": "allow",
+      "go version *": "allow",
+      "go vet *": "allow"
+    }
+  }
+}


### PR DESCRIPTION
opencode.jsonを新規追加し、go test / go version / go vet のbash実行をallowに設定。