### PR TITLE
feat: pushに--targetフィルタを統合する

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mogurastore/mdots/config"
 	"github.com/mogurastore/mdots/sync"
@@ -18,20 +19,57 @@ func main() {
 	os.Exit(run(os.Args[1:], cwd))
 }
 
+const pushUsage = "usage: mdots push [--target <name>]"
+
 func run(args []string, cwd string) int {
-	if len(args) != 1 || args[0] != "push" {
-		fmt.Fprintln(os.Stderr, "usage: mdots push")
+	if len(args) == 0 || args[0] != "push" {
+		fmt.Fprintln(os.Stderr, pushUsage)
 		return 1
 	}
-	if err := runPush(cwd); err != nil {
+	target, err := parsePushArgs(args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, pushUsage)
+		return 1
+	}
+	if err := runPush(cwd, target); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
 	return 0
 }
 
-// runPush は common の Entry のみを Store から dest へコピーする。
-func runPush(cwd string) error {
+// parsePushArgs は push の --target フラグを解釈する。
+// `--target <name>` と `--target=<name>` を受け付ける。
+func parsePushArgs(args []string) (string, error) {
+	var target string
+	seen := false
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--target":
+			if i+1 >= len(args) {
+				return "", fmt.Errorf("missing value for --target")
+			}
+			target = args[i+1]
+			i++
+			seen = true
+		case strings.HasPrefix(a, "--target="):
+			target = strings.TrimPrefix(a, "--target=")
+			seen = true
+		default:
+			return "", fmt.Errorf("unknown argument: %s", a)
+		}
+	}
+	if seen && target == "" {
+		return "", fmt.Errorf("missing value for --target")
+	}
+	return target, nil
+}
+
+// runPush は common + 指定Target の Entry を Store から dest へコピーする。
+// target 未指定時は common のみが対象になる。
+func runPush(cwd string, target string) error {
 	store, err := config.FindStore(cwd)
 	if err != nil {
 		return err
@@ -40,6 +78,6 @@ func runPush(cwd string) error {
 	if err != nil {
 		return err
 	}
-	entries := config.FilterByTarget(cfg.Entries, "")
+	entries := config.FilterByTarget(cfg.Entries, target)
 	return sync.Push(store, entries)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -87,6 +87,87 @@ func TestPushOnlyCommonEntries(t *testing.T) {
 	}
 }
 
+func TestPushWithTarget(t *testing.T) {
+	setup := func(t *testing.T) (store, home string) {
+		t.Helper()
+		store = t.TempDir()
+		home = t.TempDir()
+		t.Setenv("HOME", home)
+
+		files := map[string]string{
+			"common.conf":  "common\n",
+			"explicit.conf": "explicit\n",
+			"win.conf":     "win\n",
+			"multi.conf":   "multi\n",
+			"wsl.conf":     "wsl\n",
+		}
+		for name, body := range files {
+			if err := os.WriteFile(filepath.Join(store, name), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		yaml := "entries:\n" +
+			"  - src: common.conf\n    dest: ~/.common.conf\n" +
+			"  - src: explicit.conf\n    dest: ~/.explicit.conf\n    target: common\n" +
+			"  - src: win.conf\n    dest: ~/.win.conf\n    target: win\n" +
+			"  - src: multi.conf\n    dest: ~/.multi.conf\n    target: [win, wsl]\n" +
+			"  - src: wsl.conf\n    dest: ~/.wsl.conf\n    target: wsl\n"
+		if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return store, home
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+		not  []string
+	}{
+		{"winはcommon+win", []string{"push", "--target", "win"}, []string{".common.conf", ".explicit.conf", ".win.conf", ".multi.conf"}, []string{".wsl.conf"}},
+		{"wslはcommon+wsl(配列一致含む)", []string{"push", "--target", "wsl"}, []string{".common.conf", ".explicit.conf", ".multi.conf", ".wsl.conf"}, []string{".win.conf"}},
+		{"未知Targetはcommonのみ", []string{"push", "--target", "linux"}, []string{".common.conf", ".explicit.conf"}, []string{".win.conf", ".multi.conf", ".wsl.conf"}},
+		{"target=形式も受付", []string{"push", "--target=win"}, []string{".common.conf", ".explicit.conf", ".win.conf", ".multi.conf"}, []string{".wsl.conf"}},
+		{"target commonはcommonのみと同等", []string{"push", "--target", "common"}, []string{".common.conf", ".explicit.conf"}, []string{".win.conf", ".multi.conf", ".wsl.conf"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, home := setup(t)
+			if code := run(tt.args, store); code != 0 {
+				t.Fatalf("run(%v) exit = %d, want 0", tt.args, code)
+			}
+			for _, f := range tt.want {
+				if _, err := os.Stat(filepath.Join(home, f)); err != nil {
+					t.Errorf("%s should be copied: %v", f, err)
+				}
+			}
+			for _, f := range tt.not {
+				if _, err := os.Stat(filepath.Join(home, f)); err == nil {
+					t.Errorf("%s should NOT be copied with %v", f, tt.args)
+				}
+			}
+		})
+	}
+}
+
+func TestPushTargetFlagErrors(t *testing.T) {
+	store := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"push", "--target"},
+		{"push", "--target="},
+		{"push", "--unknown"},
+	} {
+		if code := run(args, store); code == 0 {
+			t.Errorf("run(%v): exit = 0, want non-zero", args)
+		}
+	}
+}
+
 func TestPushWithoutStoreFails(t *testing.T) {
 	empty := t.TempDir()
 	if code := run([]string{"push"}, empty); code == 0 {


### PR DESCRIPTION
Closes #4

## 概要
- `mdots push --target <name>` で common + 指定Target の Entry のみをコピー
- `--target` 未指定は common のみ（従来通り）
- `--target=<name>` 形式も受付、値欠落・未知引数は usage と共に非ゼロ終了

## 検証
- `go vet ./...` クリーン
- `go test ./...` 全パッケージPASS
- 新規テーブル駆動 `TestPushWithTarget` 5件 + `TestPushTargetFlagErrors`