### PR TITLE
feat: mdots pullでdestからStoreへの回収を実装する

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,29 +19,36 @@ func main() {
 	os.Exit(run(os.Args[1:], cwd))
 }
 
-const pushUsage = "usage: mdots push [--target <name>]"
+const usage = "usage: mdots <push|pull> [--target <name>]"
 
 func run(args []string, cwd string) int {
-	if len(args) == 0 || args[0] != "push" {
-		fmt.Fprintln(os.Stderr, pushUsage)
+	if len(args) == 0 || (args[0] != "push" && args[0] != "pull") {
+		fmt.Fprintln(os.Stderr, usage)
 		return 1
 	}
-	target, err := parsePushArgs(args[1:])
+	cmd := args[0]
+	target, err := parseTargetArgs(args[1:])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		fmt.Fprintln(os.Stderr, pushUsage)
+		fmt.Fprintln(os.Stderr, usage)
 		return 1
 	}
-	if err := runPush(cwd, target); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	var runErr error
+	if cmd == "push" {
+		runErr = runPush(cwd, target)
+	} else {
+		runErr = runPull(cwd, target)
+	}
+	if runErr != nil {
+		fmt.Fprintln(os.Stderr, runErr)
 		return 1
 	}
 	return 0
 }
 
-// parsePushArgs は push の --target フラグを解釈する。
+// parseTargetArgs は push/pull の --target フラグを解釈する。
 // `--target <name>` と `--target=<name>` を受け付ける。
-func parsePushArgs(args []string) (string, error) {
+func parseTargetArgs(args []string) (string, error) {
 	var target string
 	seen := false
 	for i := 0; i < len(args); i++ {
@@ -80,4 +87,19 @@ func runPush(cwd string, target string) error {
 	}
 	entries := config.FilterByTarget(cfg.Entries, target)
 	return sync.Push(store, entries)
+}
+
+// runPull は common + 指定Target の Entry を dest から Store へ回収する。
+// target 未指定時は common のみが対象になる。
+func runPull(cwd string, target string) error {
+	store, err := config.FindStore(cwd)
+	if err != nil {
+		return err
+	}
+	cfg, err := config.Load(filepath.Join(store, "mdots.yaml"))
+	if err != nil {
+		return err
+	}
+	entries := config.FilterByTarget(cfg.Entries, target)
+	return sync.Pull(store, entries)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -168,6 +168,126 @@ func TestPushTargetFlagErrors(t *testing.T) {
 	}
 }
 
+// Seam: CLIコマンド境界 (mdots pull)
+// 実FS上の Store/dest を用い、end-to-end の外部挙動のみを検証する。
+func TestPullEndToEnd(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := run([]string{"pull"}, store); code != 0 {
+		t.Fatalf("run(pull) exit = %d, want 0", code)
+	}
+	got, err := os.ReadFile(filepath.Join(store, "vimrc"))
+	if err != nil {
+		t.Fatalf("store read error: %v", err)
+	}
+	if string(got) != "edited\n" {
+		t.Errorf("store content = %q, want %q", got, "edited\n")
+	}
+}
+
+func TestPullWithTargetFiltersCommonPlusTarget(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(home, ".common.conf"), []byte("common edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".win.conf"), []byte("win edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".wsl.conf"), []byte("wsl edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n" +
+		"  - src: common.conf\n    dest: ~/.common.conf\n" +
+		"  - src: win.conf\n    dest: ~/.win.conf\n    target: win\n" +
+		"  - src: wsl.conf\n    dest: ~/.wsl.conf\n    target: wsl\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := run([]string{"pull", "--target", "win"}, store); code != 0 {
+		t.Fatalf("run(pull --target win) exit = %d, want 0", code)
+	}
+	if got, err := os.ReadFile(filepath.Join(store, "common.conf")); err != nil || string(got) != "common edited\n" {
+		t.Errorf("common should be pulled: content=%q err=%v", got, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(store, "win.conf")); err != nil || string(got) != "win edited\n" {
+		t.Errorf("win should be pulled: content=%q err=%v", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(store, "wsl.conf")); err == nil {
+		t.Error("wsl should NOT be pulled with --target win")
+	}
+}
+
+func TestPullMissingDestIsError(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := run([]string{"pull"}, store); code == 0 {
+		t.Error("run(pull) with missing dest: exit = 0, want non-zero")
+	}
+}
+
+func TestPullDestDirIsError(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n  - src: config\n    dest: ~/.config\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := run([]string{"pull"}, store); code == 0 {
+		t.Error("run(pull) with dir dest: exit = 0, want non-zero")
+	}
+}
+
+func TestPullWithoutStoreFails(t *testing.T) {
+	empty := t.TempDir()
+	if code := run([]string{"pull"}, empty); code == 0 {
+		t.Error("run(pull) without Store: exit = 0, want non-zero")
+	}
+}
+
+func TestPullTargetFlagErrors(t *testing.T) {
+	store := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"pull", "--target"},
+		{"pull", "--target="},
+		{"pull", "--unknown"},
+	} {
+		if code := run(args, store); code == 0 {
+			t.Errorf("run(%v): exit = 0, want non-zero", args)
+		}
+	}
+}
+
 func TestPushWithoutStoreFails(t *testing.T) {
 	empty := t.TempDir()
 	if code := run([]string{"push"}, empty); code == 0 {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -27,6 +27,24 @@ func Push(storeRoot string, entries []config.Entry) error {
 	return nil
 }
 
+// Pull は dest を Store の src へファイルコピーする。
+// Entry の src は Store 相対、dest は ~ 展開される配置先パス。
+// Push と同じく親ディレクトリは mkdir -p、パーミッションは元ファイルに追従、上書きは無確認。
+// dest が不在・ディレクトリの場合はエラーで中断する。Store 側がディレクトリの場合もエラーになる。
+func Pull(storeRoot string, entries []config.Entry) error {
+	for _, e := range entries {
+		destPath, err := config.ExpandDest(e.Dest)
+		if err != nil {
+			return fmt.Errorf("pull %s: dest expand: %w", e.Src, err)
+		}
+		srcPath := filepath.Join(storeRoot, e.Src)
+		if err := copyFile(destPath, srcPath); err != nil {
+			return fmt.Errorf("pull %s: %w", e.Src, err)
+		}
+	}
+	return nil
+}
+
 func copyFile(srcPath, destPath string) error {
 	srcInfo, err := os.Stat(srcPath)
 	if err != nil {

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -154,6 +154,162 @@ func TestPushPreservesPermission(t *testing.T) {
 	}
 }
 
+// Seam: sync パッケージ公開境界 (pull)
+// dest → Store/src のファイルコピーを t.TempDir() の実FSで検証する。
+func TestPullCopiesDestToStore(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dest := filepath.Join(home, ".vimrc")
+	if err := os.WriteFile(dest, []byte("edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "vimrc", Dest: dest}}
+
+	if err := Pull(store, entries); err != nil {
+		t.Fatalf("Pull error: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(store, "vimrc"))
+	if err != nil {
+		t.Fatalf("store read error: %v", err)
+	}
+	if string(got) != "edited\n" {
+		t.Errorf("store content = %q, want %q", got, "edited\n")
+	}
+}
+
+func TestPullCreatesParentDirsOnStoreSide(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	dest := filepath.Join(destRoot, ".config", "wezterm", "wezterm.lua")
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte("return {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: filepath.Join(".config", "wezterm", "wezterm.lua"), Dest: dest}}
+
+	if err := Pull(store, entries); err != nil {
+		t.Fatalf("Pull error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(store, ".config", "wezterm", "wezterm.lua")); err != nil {
+		t.Errorf("store src not created: %v", err)
+	}
+}
+
+func TestPullExpandsHomeDest(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(home, ".bashrc"), []byte("export X=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "bashrc", Dest: "~/.bashrc"}}
+
+	if err := Pull(store, entries); err != nil {
+		t.Fatalf("Pull error: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(store, "bashrc"))
+	if err != nil {
+		t.Fatalf("store read error: %v", err)
+	}
+	if string(got) != "export X=1\n" {
+		t.Errorf("store content = %q, want %q", got, "export X=1\n")
+	}
+}
+
+func TestPullRejectsDirectories(t *testing.T) {
+	t.Run("destがディレクトリはエラー", func(t *testing.T) {
+		store := t.TempDir()
+		destRoot := t.TempDir()
+		destDir := filepath.Join(destRoot, "existing")
+		if err := os.MkdirAll(destDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		entries := []config.Entry{{Src: "a", Dest: destDir}}
+		if err := Pull(store, entries); err == nil {
+			t.Error("エラー expected, got nil")
+		}
+	})
+
+	t.Run("Store側がディレクトリはエラー", func(t *testing.T) {
+		store := t.TempDir()
+		destRoot := t.TempDir()
+		dest := filepath.Join(destRoot, "a")
+		if err := os.WriteFile(dest, []byte("a"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(store, "a"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		entries := []config.Entry{{Src: "a", Dest: dest}}
+		if err := Pull(store, entries); err == nil {
+			t.Error("エラー expected, got nil")
+		}
+	})
+}
+
+func TestPullMissingDestIsError(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+	entries := []config.Entry{{Src: "missing", Dest: filepath.Join(destRoot, "missing")}}
+	if err := Pull(store, entries); err == nil {
+		t.Error("エラー expected, got nil")
+	}
+}
+
+func TestPullOverwritesExisting(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	dest := filepath.Join(destRoot, "a")
+	if err := os.WriteFile(dest, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcPath := filepath.Join(store, "a")
+	if err := os.WriteFile(srcPath, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "a", Dest: dest}}
+
+	if err := Pull(store, entries); err != nil {
+		t.Fatalf("Pull error: %v", err)
+	}
+	got, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Errorf("store content = %q, want %q", got, "new")
+	}
+}
+
+func TestPullPreservesPermission(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	dest := filepath.Join(destRoot, "run.sh")
+	if err := os.WriteFile(dest, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "run.sh", Dest: dest}}
+
+	if err := Pull(store, entries); err != nil {
+		t.Fatalf("Pull error: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(store, "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("store perm = %o, want 755", info.Mode().Perm())
+	}
+}
+
 func TestPushMissingSrcIsError(t *testing.T) {
 	store := t.TempDir()
 	destRoot := t.TempDir()


### PR DESCRIPTION
Closes #5

## 概要
- `sync.Pull` を追加し dest → Store/src の回収を実装（`copyFile`・`~展開`・`FilterByTarget`・親作成・ファイルのみ検証をpushと共有）
- CLIに `pull [--target]` を追加（`parseTargetArgs`・`runPull`）

## 検証
- `go vet ./...` クリーン
- `go test ./...` グリーン（sync seam + CLI seamのpull結合テスト追加）