### PR TITLE
feat: mdots diff で Store と dest の差分を表示する

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,10 +19,10 @@ func main() {
 	os.Exit(run(os.Args[1:], cwd))
 }
 
-const usage = "usage: mdots <push|pull> [--target <name>]"
+const usage = "usage: mdots <push|pull|diff> [--target <name>]"
 
 func run(args []string, cwd string) int {
-	if len(args) == 0 || (args[0] != "push" && args[0] != "pull") {
+	if len(args) == 0 || (args[0] != "push" && args[0] != "pull" && args[0] != "diff") {
 		fmt.Fprintln(os.Stderr, usage)
 		return 1
 	}
@@ -34,10 +34,19 @@ func run(args []string, cwd string) int {
 		return 1
 	}
 	var runErr error
-	if cmd == "push" {
+	switch cmd {
+	case "push":
 		runErr = runPush(cwd, target)
-	} else {
+	case "pull":
 		runErr = runPull(cwd, target)
+	case "diff":
+		var out string
+		var hasDiff bool
+		out, hasDiff, runErr = runDiff(cwd, target)
+		if runErr == nil && hasDiff {
+			fmt.Fprint(os.Stdout, out)
+			return 1
+		}
 	}
 	if runErr != nil {
 		fmt.Fprintln(os.Stderr, runErr)
@@ -46,7 +55,7 @@ func run(args []string, cwd string) int {
 	return 0
 }
 
-// parseTargetArgs は push/pull の --target フラグを解釈する。
+// parseTargetArgs は push/pull/diff の --target フラグを解釈する。
 // `--target <name>` と `--target=<name>` を受け付ける。
 func parseTargetArgs(args []string) (string, error) {
 	var target string
@@ -102,4 +111,20 @@ func runPull(cwd string, target string) error {
 	}
 	entries := config.FilterByTarget(cfg.Entries, target)
 	return sync.Pull(store, entries)
+}
+
+// runDiff は common + 指定Target の Entry について Store/src と dest の
+// 差分を diff -u 風の文字列で返す。差分があれば hasDiff=true。
+// target 未指定時は common のみが対象になる。
+func runDiff(cwd string, target string) (string, bool, error) {
+	store, err := config.FindStore(cwd)
+	if err != nil {
+		return "", false, err
+	}
+	cfg, err := config.Load(filepath.Join(store, "mdots.yaml"))
+	if err != nil {
+		return "", false, err
+	}
+	entries := config.FilterByTarget(cfg.Entries, target)
+	return sync.Diff(store, entries)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -292,5 +293,148 @@ func TestPushWithoutStoreFails(t *testing.T) {
 	empty := t.TempDir()
 	if code := run([]string{"push"}, empty); code == 0 {
 		t.Error("run(push) without Store: exit = 0, want non-zero")
+	}
+}
+
+// Seam: CLIコマンド境界 (mdots diff)
+// 実FS上の Store/dest を用い、end-to-end の外部挙動のみを検証する。
+func TestDiffNoDiffExitsZero(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("set number\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("set number\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := run([]string{"diff"}, store); code != 0 {
+		t.Errorf("run(diff) without changes: exit = %d, want 0", code)
+	}
+	out, hasDiff, err := runDiff(store, "")
+	if err != nil {
+		t.Fatalf("runDiff error: %v", err)
+	}
+	if hasDiff {
+		t.Error("hasDiff = true, want false")
+	}
+	if out != "" {
+		t.Errorf("output = %q, want empty", out)
+	}
+}
+
+func TestDiffShowsDiffAndExitsNonZero(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("set number\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("set nonumber\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := run([]string{"diff"}, store); code == 0 {
+		t.Error("run(diff) with changes: exit = 0, want non-zero")
+	}
+	out, hasDiff, err := runDiff(store, "")
+	if err != nil {
+		t.Fatalf("runDiff error: %v", err)
+	}
+	if !hasDiff {
+		t.Fatal("hasDiff = false, want true")
+	}
+	if !strings.Contains(out, "---") || !strings.Contains(out, "+++") {
+		t.Errorf("output should contain ---/+++, got %q", out)
+	}
+}
+
+func TestDiffWithTargetFiltersCommonPlusTarget(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// common は同一、win のみ差分あり、wsl は差分あっても対象外であるべき。
+	if err := os.WriteFile(filepath.Join(store, "common.conf"), []byte("common\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".common.conf"), []byte("common\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store, "win.conf"), []byte("win old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".win.conf"), []byte("win new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store, "wsl.conf"), []byte("wsl old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".wsl.conf"), []byte("wsl new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n" +
+		"  - src: common.conf\n    dest: ~/.common.conf\n" +
+		"  - src: win.conf\n    dest: ~/.win.conf\n    target: win\n" +
+		"  - src: wsl.conf\n    dest: ~/.wsl.conf\n    target: wsl\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, hasDiff, err := runDiff(store, "win")
+	if err != nil {
+		t.Fatalf("runDiff error: %v", err)
+	}
+	if !hasDiff {
+		t.Fatal("hasDiff = false, want true (win differs)")
+	}
+	if !strings.Contains(out, "---") || !strings.Contains(out, "+++") {
+		t.Errorf("output should contain ---/+++, got %q", out)
+	}
+	if strings.Contains(out, "wsl.conf") {
+		t.Errorf("output should NOT contain wsl Entry with --target win, got %q", out)
+	}
+
+	// CLI フラグ経路も検証する: win 差分ありは exit 非ゼロ、対象外のみの差分は exit 0。
+	if code := run([]string{"diff", "--target", "win"}, store); code == 0 {
+		t.Error("run(diff --target win) with win changes: exit = 0, want non-zero")
+	}
+	if code := run([]string{"diff", "--target", "linux"}, store); code != 0 {
+		t.Errorf("run(diff --target linux) without applicable changes: exit = %d, want 0", code)
+	}
+}
+
+func TestDiffWithoutStoreFails(t *testing.T) {
+	empty := t.TempDir()
+	if code := run([]string{"diff"}, empty); code == 0 {
+		t.Error("run(diff) without Store: exit = 0, want non-zero")
+	}
+}
+
+func TestDiffTargetFlagErrors(t *testing.T) {
+	store := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"diff", "--target"},
+		{"diff", "--target="},
+		{"diff", "--unknown"},
+	} {
+		if code := run(args, store); code == 0 {
+			t.Errorf("run(%v): exit = 0, want non-zero", args)
+		}
 	}
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mogurastore/mdots/config"
 )
@@ -25,6 +26,121 @@ func Push(storeRoot string, entries []config.Entry) error {
 		}
 	}
 	return nil
+}
+
+// Diff は Store の src と dest の差分を diff -u 風の文字列で返す。
+// 差分がない Entry は出力に含めない。差分が1件でもあれば hasDiff=true。
+// src/dest が不在・ディレクトリの場合はエラーで中断する。
+func Diff(storeRoot string, entries []config.Entry) (output string, hasDiff bool, err error) {
+	var sb strings.Builder
+	for _, e := range entries {
+		destPath, err := config.ExpandDest(e.Dest)
+		if err != nil {
+			return "", false, fmt.Errorf("diff %s: dest expand: %w", e.Src, err)
+		}
+		srcPath := filepath.Join(storeRoot, e.Src)
+		d, same, err := diffFile(srcPath, destPath, e.Src, e.Dest)
+		if err != nil {
+			return "", false, fmt.Errorf("diff %s: %w", e.Src, err)
+		}
+		if !same {
+			sb.WriteString(d)
+			hasDiff = true
+		}
+	}
+	return sb.String(), hasDiff, nil
+}
+
+// diffFile は2ファイルの unified diff を返す。同一内容なら same=true。
+func diffFile(srcPath, destPath, srcLabel, destLabel string) (diffText string, same bool, err error) {
+	srcInfo, err := os.Stat(srcPath)
+	if err != nil {
+		return "", false, err
+	}
+	if srcInfo.IsDir() {
+		return "", false, fmt.Errorf("src is a directory: %s", srcPath)
+	}
+	destInfo, err := os.Stat(destPath)
+	if err != nil {
+		return "", false, err
+	}
+	if destInfo.IsDir() {
+		return "", false, fmt.Errorf("dest is a directory: %s", destPath)
+	}
+	srcData, err := os.ReadFile(srcPath)
+	if err != nil {
+		return "", false, err
+	}
+	destData, err := os.ReadFile(destPath)
+	if err != nil {
+		return "", false, err
+	}
+	if string(srcData) == string(destData) {
+		return "", true, nil
+	}
+	var sb strings.Builder
+	sb.WriteString("--- " + srcLabel + "\n")
+	sb.WriteString("+++ " + destLabel + "\n")
+	sb.WriteString(unifiedBody(splitLines(string(srcData)), splitLines(string(destData))))
+	return sb.String(), false, nil
+}
+
+// splitLines は末尾改行を保持しない行分割を行う。
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	lines := strings.Split(s, "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// unifiedBody は2つの行列から @@ ハンク付きの unified diff 本体を作る。
+// LCS ベースの単純な差分で、dotfiles 程度の小規模ファイルを想定する。
+func unifiedBody(srcLines, destLines []string) string {
+	n, m := len(srcLines), len(destLines)
+	dp := make([][]int, n+1)
+	for i := range dp {
+		dp[i] = make([]int, m+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if srcLines[i] == destLines[j] {
+				dp[i][j] = dp[i+1][j+1] + 1
+			} else if dp[i+1][j] >= dp[i][j+1] {
+				dp[i][j] = dp[i+1][j]
+			} else {
+				dp[i][j] = dp[i][j+1]
+			}
+		}
+	}
+	type op struct {
+		kind string
+		line string
+	}
+	var ops []op
+	for i, j := 0, 0; i < n || j < m; {
+		switch {
+		case i < n && j < m && srcLines[i] == destLines[j]:
+			ops = append(ops, op{" ", srcLines[i]})
+			i++
+			j++
+		case j >= m || (i < n && dp[i+1][j] >= dp[i][j+1]):
+			ops = append(ops, op{"-", srcLines[i]})
+			i++
+		default:
+			ops = append(ops, op{"+", destLines[j]})
+			j++
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("@@ -%d,%d +%d,%d @@\n", 1, n, 1, m))
+	for _, o := range ops {
+		sb.WriteString(o.kind + o.line + "\n")
+	}
+	return sb.String()
 }
 
 // Pull は dest を Store の src へファイルコピーする。

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mogurastore/mdots/config"
@@ -316,5 +317,125 @@ func TestPushMissingSrcIsError(t *testing.T) {
 	entries := []config.Entry{{Src: "missing", Dest: filepath.Join(destRoot, "missing")}}
 	if err := Push(store, entries); err == nil {
 		t.Error("エラー expected, got nil")
+	}
+}
+
+// Seam: sync パッケージ公開境界 (diff)
+// Store/src と dest の差分を diff -u 風に出力する。実FSで検証する。
+func TestDiffNoDiffWhenIdentical(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	srcPath := filepath.Join(store, "vimrc")
+	if err := os.WriteFile(srcPath, []byte("set number\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(destRoot, ".vimrc")
+	if err := os.WriteFile(dest, []byte("set number\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "vimrc", Dest: dest}}
+
+	out, hasDiff, err := Diff(store, entries)
+	if err != nil {
+		t.Fatalf("Diff error: %v", err)
+	}
+	if hasDiff {
+		t.Error("hasDiff = true, want false")
+	}
+	if out != "" {
+		t.Errorf("output = %q, want empty", out)
+	}
+}
+
+func TestDiffShowsUnifiedDiffWhenDifferent(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	srcPath := filepath.Join(store, "vimrc")
+	if err := os.WriteFile(srcPath, []byte("set number\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(destRoot, ".vimrc")
+	if err := os.WriteFile(dest, []byte("set nonumber\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "vimrc", Dest: dest}}
+
+	out, hasDiff, err := Diff(store, entries)
+	if err != nil {
+		t.Fatalf("Diff error: %v", err)
+	}
+	if !hasDiff {
+		t.Fatal("hasDiff = false, want true")
+	}
+	if !strings.Contains(out, "---") || !strings.Contains(out, "+++") {
+		t.Errorf("output should contain ---/+++, got %q", out)
+	}
+}
+
+func TestDiffMissingFileIsError(t *testing.T) {
+	t.Run("src不在はエラー", func(t *testing.T) {
+		store := t.TempDir()
+		destRoot := t.TempDir()
+		dest := filepath.Join(destRoot, "a")
+		if err := os.WriteFile(dest, []byte("a"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		entries := []config.Entry{{Src: "missing", Dest: dest}}
+		if _, _, err := Diff(store, entries); err == nil {
+			t.Error("エラー expected, got nil")
+		}
+	})
+
+	t.Run("dest不在はエラー", func(t *testing.T) {
+		store := t.TempDir()
+		destRoot := t.TempDir()
+		if err := os.WriteFile(filepath.Join(store, "a"), []byte("a"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		entries := []config.Entry{{Src: "a", Dest: filepath.Join(destRoot, "missing")}}
+		if _, _, err := Diff(store, entries); err == nil {
+			t.Error("エラー expected, got nil")
+		}
+	})
+}
+
+func TestDiffMultipleEntriesOnlyDifferingOutput(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(store, "same"), []byte("same\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(destRoot, "same"), []byte("same\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store, "changed"), []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(destRoot, "changed"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{
+		{Src: "same", Dest: filepath.Join(destRoot, "same")},
+		{Src: "changed", Dest: filepath.Join(destRoot, "changed")},
+	}
+
+	out, hasDiff, err := Diff(store, entries)
+	if err != nil {
+		t.Fatalf("Diff error: %v", err)
+	}
+	if !hasDiff {
+		t.Fatal("hasDiff = false, want true")
+	}
+	if !strings.Contains(out, "changed") {
+		t.Errorf("output should mention changed Entry, got %q", out)
+	}
+	if strings.Contains(out, "--- same") {
+		t.Errorf("output should NOT contain same Entry, got %q", out)
+	}
+	if !strings.Contains(out, "-old") || !strings.Contains(out, "+new") {
+		t.Errorf("output should contain -/+ lines, got %q", out)
 	}
 }


### PR DESCRIPTION
Closes #6

## 概要
- `mdots diff [--target <name>]` で Store/src と dest の差分を diff -u 風に出力する
- 差分なしは無出力・exit 0、差分ありは `---`/`+++` を含む出力を stdout に出して exit 1
- Target フィルタは pull/push と同一（common + 指定 Target）

## テスト
- `go vet ./...`、`go test ./... -count=1` 全パス
- sync 境界・CLI 境界ともに実FS（t.TempDir()）で外部挙動を検証