### PR TITLE
feat: CLIポリッシュと配布を実装する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go test ./...
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ apm_modules/
 
 # opencode local config (per-user)
 opencode.json
+
+# GoReleaser
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,31 @@
+version: 2
+
+project_name: mdots
+
+builds:
+  - main: .
+    binary: mdots
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: checksums.txt
+
+snapshot:
+  version_template: "{{ .Tag }}-next"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# mdots
+
+dotfilesをファイルコピー（非symlink）で管理するCLI。
+Store（`mdots.yaml` を含む管理リポジトリのルート）とホーム側を `push` / `pull` / `diff` で同期する。
+
+## 導入
+
+いずれかの方法で導入できる。
+
+```sh
+# go install
+go install github.com/mogurastore/mdots@latest
+
+# mise (ubi バックエンド)
+mise use ubi:mogurastore/mdots@latest
+
+# GitHub Releases からバイナリを取得
+# https://github.com/mogurastore/mdots/releases から OS/Arch に合う
+# mdots-<version>-<os>-<arch>.tar.gz (Windows は .zip) を展開する
+```
+
+## 最小サンプル
+
+Store（管理リポジトリ）の直下に `mdots.yaml` を置く。
+`src` は Store 相対のファイルパス、`dest` は `~` 展開される配置先パス、
+`target` は省略時 common 扱いの自由文字列（例: `win`, `wsl`）。
+
+```yaml
+# <Store>/mdots.yaml
+entries:
+  - src: vimrc
+    dest: ~/.vimrc
+  - src: wezterm.lua
+    dest: ~/.config/wezterm/wezterm.lua
+    target: win
+  - src: shared.conf
+    dest: ~/.config/shared.conf
+    target: [win, wsl]
+```
+
+```sh
+mdots push              # common のみを Store から dest へコピー
+mdots push --target win # common + win を対象にする
+mdots pull --target win # dest から Store へ回収する
+mdots diff              # 差分を diff -u 風に確認する（差分なし: exit 0、差分あり: exit 1）
+```
+
+## 使い方
+
+```sh
+mdots --help            # 使い方を表示する
+mdots push --help       # コマンド別の使い方を表示する
+mdots --version         # バージョンを表示する（ldflags -X main.version で埋め込み）
+```
+
+> 補足: `go install @latest` で導入した場合はバージョンが `mdots dev` と表示される。
+> タグ付きバージョンは GitHub Releases のバイナリでのみ埋め込まれる。
+
+| コマンド | 意味 |
+| --- | --- |
+| `push [--target <name>] [--dry-run]` | Store から dest へコピーする |
+| `pull [--target <name>] [--dry-run]` | dest から Store へ回収する |
+| `diff [--target <name>]` | Store と dest の差分を表示する |
+
+- `--target` 未指定時は common のみ、指定時は common + 指定 Target が対象になる。
+- `--dry-run` は実際に書き込まず差分相当を出力する。差分ありは exit 1、差分なしは exit 0。
+- `mdots.yaml` が見つからないときは `mdots.yaml not found: searched from <cwd> to /` と表示し exit 1 になる。
+- Store はカレントから親方向に `mdots.yaml` を探索して発見する。サブディレクトリからでも実行できる。

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Seam: CLIコマンド境界 (mdots --help / --version)
+// 実FSは使わず、外部挙動（exit codeと出力文面）のみを検証する。
+func TestGlobalHelp(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if code := runWithWriters([]string{"--help"}, t.TempDir(), &out, &errOut); code != 0 {
+		t.Fatalf("run(--help) exit = %d, want 0", code)
+	}
+	got := out.String()
+	for _, want := range []string{"usage:", "push", "pull", "diff"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("help output should contain %q, got %q", want, got)
+		}
+	}
+}
+
+func TestGlobalHelpShortFlag(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if code := runWithWriters([]string{"-h"}, t.TempDir(), &out, &errOut); code != 0 {
+		t.Fatalf("run(-h) exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "usage:") {
+		t.Errorf("help output should contain usage:, got %q", out.String())
+	}
+}
+
+func TestPushHelp(t *testing.T) {
+	for _, args := range [][]string{{"push", "--help"}, {"push", "-h"}} {
+		var out, errOut bytes.Buffer
+		store := t.TempDir()
+		if code := runWithWriters(args, store, &out, &errOut); code != 0 {
+			t.Fatalf("run(%v) exit = %d, want 0", args, code)
+		}
+		got := out.String()
+		for _, want := range []string{"push", "--target", "--dry-run"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("run(%v): output should contain %q, got %q", args, want, got)
+			}
+		}
+	}
+}
+
+func TestPullHelp(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if code := runWithWriters([]string{"pull", "--help"}, t.TempDir(), &out, &errOut); code != 0 {
+		t.Fatalf("run(pull --help) exit = %d, want 0", code)
+	}
+	for _, want := range []string{"pull", "--target", "--dry-run"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output should contain %q, got %q", want, out.String())
+		}
+	}
+}
+
+func TestDiffHelp(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if code := runWithWriters([]string{"diff", "--help"}, t.TempDir(), &out, &errOut); code != 0 {
+		t.Fatalf("run(diff --help) exit = %d, want 0", code)
+	}
+	for _, want := range []string{"diff", "--target"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output should contain %q, got %q", want, out.String())
+		}
+	}
+}
+
+func TestVersion(t *testing.T) {
+	old := version
+	version = "v0.0.0-test"
+	defer func() { version = old }()
+
+	var out, errOut bytes.Buffer
+	if code := runWithWriters([]string{"--version"}, t.TempDir(), &out, &errOut); code != 0 {
+		t.Fatalf("run(--version) exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "v0.0.0-test") {
+		t.Errorf("version output should contain %q, got %q", "v0.0.0-test", out.String())
+	}
+}
+
+// Seam: CLIコマンド境界 (mdots push/pull --dry-run)
+// 実FS上の Store/dest を用い、書き込みなし・差分相当出力の外部挙動のみを検証する。
+func TestPushDryRunDoesNotWriteButShowsDiff(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := runWithWriters([]string{"push", "--dry-run"}, store, &out, &errOut)
+	if code == 0 {
+		t.Error("run(push --dry-run) with changes: exit = 0, want non-zero")
+	}
+	if !strings.Contains(out.String(), "---") || !strings.Contains(out.String(), "+++") {
+		t.Errorf("dry-run output should contain ---/+++, got %q", out.String())
+	}
+	got, err := os.ReadFile(filepath.Join(home, ".vimrc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old\n" {
+		t.Errorf("dest must NOT be written on dry-run: content = %q, want %q", got, "old\n")
+	}
+}
+
+func TestPushDryRunNoDiffExitsZero(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("same\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("same\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	if code := runWithWriters([]string{"push", "--dry-run"}, store, &out, &errOut); code != 0 {
+		t.Errorf("run(push --dry-run) without changes: exit = %d, want 0", code)
+	}
+}
+
+func TestPullDryRunDoesNotWriteButShowsDiff(t *testing.T) {
+	store := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := runWithWriters([]string{"pull", "--dry-run"}, store, &out, &errOut)
+	if code == 0 {
+		t.Error("run(pull --dry-run) with changes: exit = 0, want non-zero")
+	}
+	if !strings.Contains(out.String(), "---") || !strings.Contains(out.String(), "+++") {
+		t.Errorf("dry-run output should contain ---/+++, got %q", out.String())
+	}
+	got, err := os.ReadFile(filepath.Join(store, "vimrc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old\n" {
+		t.Errorf("Store must NOT be written on dry-run: content = %q, want %q", got, "old\n")
+	}
+}
+
+func TestDiffRejectsDryRun(t *testing.T) {
+	store := t.TempDir()
+	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	if code := runWithWriters([]string{"diff", "--dry-run"}, store, &out, &errOut); code == 0 {
+		t.Error("run(diff --dry-run): exit = 0, want non-zero")
+	}
+}
+
+func TestStoreNotFoundFriendlyError(t *testing.T) {
+	empty := t.TempDir()
+	var out, errOut bytes.Buffer
+	if code := runWithWriters([]string{"push"}, empty, &out, &errOut); code == 0 {
+		t.Fatal("run(push) without Store: exit = 0, want non-zero")
+	}
+	if !strings.Contains(errOut.String(), "mdots.yaml not found: searched from ") {
+		t.Errorf("stderr should contain friendly message, got %q", errOut.String())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,10 @@ import (
 	"github.com/mogurastore/mdots/config"
 	"github.com/mogurastore/mdots/sync"
 )
+
+// version はリリース時に ldflags -X main.version=<tag> で埋め込む。
+// 未指定時の既定値は dev。
+var version = "dev"
 
 func main() {
 	cwd, err := os.Getwd()
@@ -21,95 +26,211 @@ func main() {
 
 const usage = "usage: mdots <push|pull|diff> [--target <name>]"
 
-func run(args []string, cwd string) int {
-	if len(args) == 0 || (args[0] != "push" && args[0] != "pull" && args[0] != "diff") {
-		fmt.Fprintln(os.Stderr, usage)
-		return 1
-	}
-	cmd := args[0]
-	target, err := parseTargetArgs(args[1:])
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		fmt.Fprintln(os.Stderr, usage)
-		return 1
-	}
-	var runErr error
+const globalHelp = `usage: mdots <push|pull|diff> [options]
+
+dotfilesをファイルコピー（非symlink）で管理するCLI。
+Store（mdots.yaml を含む管理リポジトリのルート）をカレントから親方向に探索する。
+
+commands:
+  push  Storeからdestへファイルをコピーする
+  pull  destからStoreへファイルを回収する
+  diff  Storeとdestの差分を表示する
+
+global options:
+  -h, --help     使い方を表示する
+  --version      バージョンを表示する
+
+run 'mdots <command> --help' for command-specific help.
+`
+
+const pushHelp = `usage: mdots push [--target <name>] [--dry-run]
+
+Storeからdestへファイルをコピーする。
+--target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
+
+options:
+  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
+  --dry-run        実際に書き込まず差分相当を出力する。差分ありは exit 1
+  -h, --help       使い方を表示する
+`
+
+const pullHelp = `usage: mdots pull [--target <name>] [--dry-run]
+
+destからStoreへファイルを回収する。
+--target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
+
+options:
+  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
+  --dry-run        実際に書き込まず差分相当を出力する。差分ありは exit 1
+  -h, --help       使い方を表示する
+`
+
+const diffHelp = `usage: mdots diff [--target <name>]
+
+Storeとdestの差分を diff -u 風に出力する。
+差分なしは無出力・exit 0、差分ありは差分を出力し exit 1。
+--target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
+
+options:
+  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
+  -h, --help       使い方を表示する
+`
+
+func commandHelp(cmd string) string {
 	switch cmd {
 	case "push":
-		runErr = runPush(cwd, target)
+		return pushHelp
 	case "pull":
-		runErr = runPull(cwd, target)
+		return pullHelp
 	case "diff":
-		var out string
-		var hasDiff bool
-		out, hasDiff, runErr = runDiff(cwd, target)
-		if runErr == nil && hasDiff {
-			fmt.Fprint(os.Stdout, out)
-			return 1
-		}
+		return diffHelp
+	default:
+		return globalHelp
 	}
-	if runErr != nil {
-		fmt.Fprintln(os.Stderr, runErr)
-		return 1
-	}
-	return 0
 }
 
-// parseTargetArgs は push/pull/diff の --target フラグを解釈する。
-// `--target <name>` と `--target=<name>` を受け付ける。
-func parseTargetArgs(args []string) (string, error) {
-	var target string
+func run(args []string, cwd string) int {
+	return runWithWriters(args, cwd, os.Stdout, os.Stderr)
+}
+
+func runWithWriters(args []string, cwd string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprint(stderr, globalHelp)
+		return 1
+	}
+	switch args[0] {
+	case "--help", "-h":
+		fmt.Fprint(stdout, globalHelp)
+		return 0
+	case "--version", "-V", "version":
+		fmt.Fprintf(stdout, "mdots %s\n", version)
+		return 0
+	}
+	cmd := args[0]
+	if cmd != "push" && cmd != "pull" && cmd != "diff" {
+		fmt.Fprintf(stderr, "unknown command: %s\n", cmd)
+		fmt.Fprint(stderr, globalHelp)
+		return 1
+	}
+	allowDryRun := cmd == "push" || cmd == "pull"
+	opts, err := parseCmdArgs(args[1:], allowDryRun)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		fmt.Fprint(stderr, commandHelp(cmd))
+		return 1
+	}
+	if opts.help {
+		fmt.Fprint(stdout, commandHelp(cmd))
+		return 0
+	}
+	switch cmd {
+	case "push":
+		if opts.dryRun {
+			return runPushDryRun(cwd, opts.target, stdout, stderr)
+		}
+		if err := runPush(cwd, opts.target); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	case "pull":
+		if opts.dryRun {
+			return runPullDryRun(cwd, opts.target, stdout, stderr)
+		}
+		if err := runPull(cwd, opts.target); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	case "diff":
+		out, hasDiff, err := runDiff(cwd, opts.target)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if hasDiff {
+			fmt.Fprint(stdout, out)
+			return 1
+		}
+		return 0
+	}
+	return 1
+}
+
+// cmdOptions は push/pull/diff のコマンドフラグを表す。
+type cmdOptions struct {
+	target string
+	dryRun bool
+	help   bool
+}
+
+// parseCmdArgs は push/pull/diff のフラグを解釈する。
+// `--target <name>` と `--target=<name>`、`--dry-run`、`-h/--help` を受け付ける。
+// diff では --dry-run を拒否する (allowDryRun=false)。
+func parseCmdArgs(args []string, allowDryRun bool) (cmdOptions, error) {
+	var opts cmdOptions
 	seen := false
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		switch {
 		case a == "--target":
 			if i+1 >= len(args) {
-				return "", fmt.Errorf("missing value for --target")
+				return cmdOptions{}, fmt.Errorf("missing value for --target")
 			}
-			target = args[i+1]
+			opts.target = args[i+1]
 			i++
 			seen = true
 		case strings.HasPrefix(a, "--target="):
-			target = strings.TrimPrefix(a, "--target=")
+			opts.target = strings.TrimPrefix(a, "--target=")
 			seen = true
+		case a == "--dry-run":
+			if !allowDryRun {
+				return cmdOptions{}, fmt.Errorf("--dry-run is only supported for push/pull")
+			}
+			opts.dryRun = true
+		case a == "--help" || a == "-h":
+			opts.help = true
 		default:
-			return "", fmt.Errorf("unknown argument: %s", a)
+			return cmdOptions{}, fmt.Errorf("unknown argument: %s", a)
 		}
 	}
-	if seen && target == "" {
-		return "", fmt.Errorf("missing value for --target")
+	if seen && opts.target == "" {
+		return cmdOptions{}, fmt.Errorf("missing value for --target")
 	}
-	return target, nil
+	return opts, nil
+}
+
+// resolveEntries は Store 発見・設定読込・Target フィルタをまとめて行い、
+// push/pull/diff とその dry-run で共有する。
+func resolveEntries(cwd string, target string) (string, []config.Entry, error) {
+	store, err := config.FindStore(cwd)
+	if err != nil {
+		return "", nil, err
+	}
+	cfg, err := config.Load(filepath.Join(store, "mdots.yaml"))
+	if err != nil {
+		return "", nil, err
+	}
+	return store, config.FilterByTarget(cfg.Entries, target), nil
 }
 
 // runPush は common + 指定Target の Entry を Store から dest へコピーする。
 // target 未指定時は common のみが対象になる。
 func runPush(cwd string, target string) error {
-	store, err := config.FindStore(cwd)
+	store, entries, err := resolveEntries(cwd, target)
 	if err != nil {
 		return err
 	}
-	cfg, err := config.Load(filepath.Join(store, "mdots.yaml"))
-	if err != nil {
-		return err
-	}
-	entries := config.FilterByTarget(cfg.Entries, target)
 	return sync.Push(store, entries)
 }
 
 // runPull は common + 指定Target の Entry を dest から Store へ回収する。
 // target 未指定時は common のみが対象になる。
 func runPull(cwd string, target string) error {
-	store, err := config.FindStore(cwd)
+	store, entries, err := resolveEntries(cwd, target)
 	if err != nil {
 		return err
 	}
-	cfg, err := config.Load(filepath.Join(store, "mdots.yaml"))
-	if err != nil {
-		return err
-	}
-	entries := config.FilterByTarget(cfg.Entries, target)
 	return sync.Pull(store, entries)
 }
 
@@ -117,14 +238,49 @@ func runPull(cwd string, target string) error {
 // 差分を diff -u 風の文字列で返す。差分があれば hasDiff=true。
 // target 未指定時は common のみが対象になる。
 func runDiff(cwd string, target string) (string, bool, error) {
-	store, err := config.FindStore(cwd)
+	store, entries, err := resolveEntries(cwd, target)
 	if err != nil {
 		return "", false, err
 	}
-	cfg, err := config.Load(filepath.Join(store, "mdots.yaml"))
-	if err != nil {
-		return "", false, err
-	}
-	entries := config.FilterByTarget(cfg.Entries, target)
 	return sync.Diff(store, entries)
+}
+
+// runPushDryRun は push の差分相当を stdout に出し、書き込みは行わない。
+// 差分ありは exit 1、差分なしは exit 0。
+func runPushDryRun(cwd string, target string, stdout, stderr io.Writer) int {
+	store, entries, err := resolveEntries(cwd, target)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	out, hasDiff, err := sync.DryRunPush(store, entries)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if hasDiff {
+		fmt.Fprint(stdout, out)
+		return 1
+	}
+	return 0
+}
+
+// runPullDryRun は pull の差分相当を stdout に出し、書き込みは行わない。
+// 差分ありは exit 1、差分なしは exit 0。
+func runPullDryRun(cwd string, target string, stdout, stderr io.Writer) int {
+	store, entries, err := resolveEntries(cwd, target)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	out, hasDiff, err := sync.DryRunPull(store, entries)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if hasDiff {
+		fmt.Fprint(stdout, out)
+		return 1
+	}
+	return 0
 }

--- a/sync/dryrun_test.go
+++ b/sync/dryrun_test.go
@@ -1,0 +1,137 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mogurastore/mdots/config"
+)
+
+// Seam: sync パッケージ公開境界 (push/pull の dry-run)
+// 実FS上で書き込みなし・差分相当出力の外部挙動のみを検証する。
+func TestDryRunPushShowsDiffWithoutWriting(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(store, "a"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(destRoot, "a")
+	if err := os.WriteFile(dest, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "a", Dest: dest}}
+
+	out, hasDiff, err := DryRunPush(store, entries)
+	if err != nil {
+		t.Fatalf("DryRunPush error: %v", err)
+	}
+	if !hasDiff {
+		t.Fatal("hasDiff = false, want true")
+	}
+	if !strings.Contains(out, "---") || !strings.Contains(out, "+++") {
+		t.Errorf("output should contain ---/+++, got %q", out)
+	}
+	if got, _ := os.ReadFile(dest); string(got) != "old\n" {
+		t.Errorf("dest must NOT be written: content = %q, want %q", got, "old\n")
+	}
+}
+
+func TestDryRunPushReportsNewFileWithoutCreating(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(store, "a"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(destRoot, "a")
+	entries := []config.Entry{{Src: "a", Dest: dest}}
+
+	out, hasDiff, err := DryRunPush(store, entries)
+	if err != nil {
+		t.Fatalf("DryRunPush error: %v", err)
+	}
+	if !hasDiff {
+		t.Fatal("hasDiff = false, want true (new file)")
+	}
+	if out == "" {
+		t.Error("output empty, want new-file notice")
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Errorf("dest must NOT be created on dry-run: stat err = %v", err)
+	}
+}
+
+func TestDryRunPushMissingSrcIsError(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+	entries := []config.Entry{{Src: "missing", Dest: filepath.Join(destRoot, "missing")}}
+	if _, _, err := DryRunPush(store, entries); err == nil {
+		t.Error("エラー expected, got nil")
+	}
+}
+
+func TestDryRunPullShowsDiffWithoutWriting(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	srcPath := filepath.Join(store, "a")
+	if err := os.WriteFile(srcPath, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(destRoot, "a")
+	if err := os.WriteFile(dest, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "a", Dest: dest}}
+
+	out, hasDiff, err := DryRunPull(store, entries)
+	if err != nil {
+		t.Fatalf("DryRunPull error: %v", err)
+	}
+	if !hasDiff {
+		t.Fatal("hasDiff = false, want true")
+	}
+	if !strings.Contains(out, "---") || !strings.Contains(out, "+++") {
+		t.Errorf("output should contain ---/+++, got %q", out)
+	}
+	if got, _ := os.ReadFile(srcPath); string(got) != "old\n" {
+		t.Errorf("Store must NOT be written: content = %q, want %q", got, "old\n")
+	}
+}
+
+func TestDryRunPullReportsNewStoreFileWithoutCreating(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+
+	dest := filepath.Join(destRoot, "a")
+	if err := os.WriteFile(dest, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.Entry{{Src: "a", Dest: dest}}
+
+	out, hasDiff, err := DryRunPull(store, entries)
+	if err != nil {
+		t.Fatalf("DryRunPull error: %v", err)
+	}
+	if !hasDiff {
+		t.Fatal("hasDiff = false, want true (new Store file)")
+	}
+	if out == "" {
+		t.Error("output empty, want new-file notice")
+	}
+	if _, err := os.Stat(filepath.Join(store, "a")); !os.IsNotExist(err) {
+		t.Errorf("Store src must NOT be created on dry-run: stat err = %v", err)
+	}
+}
+
+func TestDryRunPullMissingDestIsError(t *testing.T) {
+	store := t.TempDir()
+	destRoot := t.TempDir()
+	entries := []config.Entry{{Src: "a", Dest: filepath.Join(destRoot, "missing")}}
+	if _, _, err := DryRunPull(store, entries); err == nil {
+		t.Error("エラー expected, got nil")
+	}
+}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -143,6 +143,85 @@ func unifiedBody(srcLines, destLines []string) string {
 	return sb.String()
 }
 
+// DryRunPush は push の差分相当を返す。実際の書き込みは行わない。
+// 両方存在する Entry は Diff と同じ unified diff を出し、
+// dest 不在の Entry は新規作成予定として報告する。
+// src 不在・ディレクトリは push と同様にエラーで中断する。
+func DryRunPush(storeRoot string, entries []config.Entry) (output string, hasDiff bool, err error) {
+	return dryRun(storeRoot, entries, "push")
+}
+
+// DryRunPull は pull の差分相当を返す。実際の書き込みは行わない。
+// 両方存在する Entry は Diff と同じ unified diff を出し、
+// Store の src 不在の Entry は新規回収予定として報告する。
+// dest 不在・ディレクトリは pull と同様にエラーで中断する。
+func DryRunPull(storeRoot string, entries []config.Entry) (output string, hasDiff bool, err error) {
+	return dryRun(storeRoot, entries, "pull")
+}
+
+// dryRun は direction ("push"/"pull") に応じた欠落時の扱いで差分相当を作る。
+func dryRun(storeRoot string, entries []config.Entry, direction string) (string, bool, error) {
+	var sb strings.Builder
+	hasDiff := false
+	for _, e := range entries {
+		destPath, err := config.ExpandDest(e.Dest)
+		if err != nil {
+			return "", false, fmt.Errorf("dry-run %s %s: dest expand: %w", direction, e.Src, err)
+		}
+		srcPath := filepath.Join(storeRoot, e.Src)
+		if direction == "push" {
+			srcInfo, err := os.Stat(srcPath)
+			if err != nil {
+				return "", false, fmt.Errorf("dry-run push %s: %w", e.Src, err)
+			}
+			if srcInfo.IsDir() {
+				return "", false, fmt.Errorf("dry-run push %s: src is a directory: %s", e.Src, srcPath)
+			}
+			if destInfo, err := os.Stat(destPath); err != nil {
+				if !os.IsNotExist(err) {
+					return "", false, fmt.Errorf("dry-run push %s: %w", e.Src, err)
+				}
+				sb.WriteString("--- " + e.Src + "\n")
+				sb.WriteString("+++ " + e.Dest + "\n")
+				sb.WriteString("(new file: " + e.Dest + " would be created)\n")
+				hasDiff = true
+				continue
+			} else if destInfo.IsDir() {
+				return "", false, fmt.Errorf("dry-run push %s: dest is a directory: %s", e.Src, destPath)
+			}
+		} else {
+			destInfo, err := os.Stat(destPath)
+			if err != nil {
+				return "", false, fmt.Errorf("dry-run pull %s: %w", e.Src, err)
+			}
+			if destInfo.IsDir() {
+				return "", false, fmt.Errorf("dry-run pull %s: dest is a directory: %s", e.Src, destPath)
+			}
+			if srcInfo, err := os.Stat(srcPath); err != nil {
+				if !os.IsNotExist(err) {
+					return "", false, fmt.Errorf("dry-run pull %s: %w", e.Src, err)
+				}
+				sb.WriteString("--- " + e.Src + "\n")
+				sb.WriteString("+++ " + e.Dest + "\n")
+				sb.WriteString("(new file: " + e.Src + " would be created in Store)\n")
+				hasDiff = true
+				continue
+			} else if srcInfo.IsDir() {
+				return "", false, fmt.Errorf("dry-run pull %s: Store src is a directory: %s", e.Src, srcPath)
+			}
+		}
+		d, same, err := diffFile(srcPath, destPath, e.Src, e.Dest)
+		if err != nil {
+			return "", false, fmt.Errorf("dry-run %s %s: %w", direction, e.Src, err)
+		}
+		if !same {
+			sb.WriteString(d)
+			hasDiff = true
+		}
+	}
+	return sb.String(), hasDiff, nil
+}
+
 // Pull は dest を Store の src へファイルコピーする。
 // Entry の src は Store 相対、dest は ~ 展開される配置先パス。
 // Push と同じく親ディレクトリは mkdir -p、パーミッションは元ファイルに追従、上書きは無確認。


### PR DESCRIPTION
Refs #7 (Part of #1)

## 内容

- `push` / `pull --dry-run`: 書き込みなしで差分相当を出力（差分あり exit 1）
- `mdots --help` / `push|pull|diff --help`、`mdots --version`（`ldflags -X main.version` 埋め込み）
- `mdots.yaml not found: searched from <cwd> to /` のCLI経路テスト追加
- 配布: `.goreleaser.yaml` + `release.yml`（`v*` タグ起動）+ README導入・最小サンプル

## 検証

- `go vet ./...`、`go test ./... -count=1` 通過
- code-review（Standards / Spec の2軸）実施済み

## 残件（マージ後）

- `v*` タグpushで初回Releaseを作成し、`mise use ubi:mogurastore/mdots` / `go install` の解決を確認したら #7 の最終チェックを入れてクローズする