### PR TITLE
CLI骨格をurfave/cli v3に置換し表面同等にする

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,354 @@
+// Package cli は mdots のコマンド骨格を定義する。
+//
+// CLIフレームワークの最終採用は urfave/cli v3（宣言ツリーで push/pull/diff と
+// --target/--dry-run を定義する）。pflagのみによる自前解析は段階移行の予備案
+// として残すが、既定は v3 とする（spec #24 の Implementation Decisions による）。
+//
+// CLI表面（help/version/unknown時の文面・--target形式・push/pullのみ--dry-run・
+// exitの振る舞い）は凍結値のまま変えない。内部実行は Executor 委譲とし、
+// エントリは薄く保つ。
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	cliv3 "github.com/urfave/cli/v3"
+)
+
+const GlobalHelp = `usage: mdots <push|pull|diff> [options]
+
+dotfilesをファイルコピー（非symlink）で管理するCLI。
+Store（mdots.yaml を含む管理リポジトリのルート）をカレントから親方向に探索する。
+
+commands:
+  push  Storeからdestへファイルをコピーする
+  pull  destからStoreへファイルを回収する
+  diff  Storeとdestの差分を表示する
+
+global options:
+  -h, --help     使い方を表示する
+  --version      バージョンを表示する
+
+run 'mdots <command> --help' for command-specific help.
+`
+
+const PushHelp = `usage: mdots push [--target <name>] [--dry-run]
+
+Storeからdestへファイルをコピーする。
+--target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
+
+options:
+  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
+  --dry-run        実際に書き込まず差分相当を出力する。差分ありは exit 1
+  -h, --help       使い方を表示する
+`
+
+const PullHelp = `usage: mdots pull [--target <name>] [--dry-run]
+
+destからStoreへファイルを回収する。
+--target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
+
+options:
+  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
+  --dry-run        実際に書き込まず差分相当を出力する。差分ありは exit 1
+  -h, --help       使い方を表示する
+`
+
+const DiffHelp = `usage: mdots diff [--target <name>]
+
+Storeとdestの差分を diff -u 風に出力する。
+差分なしは無出力・exit 0、差分ありは差分を出力し exit 1。
+--target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
+
+options:
+  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
+  -h, --help       使い方を表示する
+`
+
+// Executor は push/pull/diff の内部実行系への委譲口である。
+// 表面（文面・exit）は本パッケージが保ち、副作用のある処理だけを委譲する。
+type Executor interface {
+	Push(cwd, target string) error
+	Pull(cwd, target string) error
+	Diff(cwd, target string) (out string, hasDiff bool, err error)
+	PushDryRun(cwd, target string, stdout, stderr io.Writer) int
+	PullDryRun(cwd, target string, stdout, stderr io.Writer) int
+}
+
+// exitError は Action が呼び出し元 Run へ exit code を伝えるための内用エラーで、
+// 出力は Action 側で済ませているため文面を持たない。
+type exitError struct{ code int }
+
+func (e *exitError) Error() string { return fmt.Sprintf("exit %d", e.code) }
+
+// runner は1回の Run 呼び出しに対応する宣言ツリーと入出力を束ねる。
+type runner struct {
+	version string
+	exec    Executor
+	cwd     string
+	stdout  io.Writer
+	stderr  io.Writer
+	// cmdArgs はサブコマンド名より後ろの生トークンである。未知フラグの報告時に
+	// フレームワークが正規化した名前から元の綴り（-V と --V の区別など）を復元する。
+	cmdArgs []string
+}
+
+// Run は CLI表面の入口である。args は os.Args[1:] 相当、cwd は実行ディレクトリ。
+// 戻り値はプロセスの exit code。
+func Run(args []string, cwd, version string, ex Executor, stdout, stderr io.Writer) int {
+	r := &runner{version: version, exec: ex, cwd: cwd, stdout: stdout, stderr: stderr}
+
+	// 先頭トークンの事前振り分け。従来の自前解析は先頭トークンだけで
+	// help/version/unknown を確定させていたため、その優先順位を凍結値のまま保つ。
+	// push/pull/diff の詳細なフラグ解釈は宣言ツリーに任せる。
+	if len(args) == 0 {
+		fmt.Fprint(stderr, GlobalHelp)
+		return 1
+	}
+	switch args[0] {
+	case "--help", "-h":
+		fmt.Fprint(stdout, GlobalHelp)
+		return 0
+	case "--version", "-V", "version":
+		fmt.Fprintf(stdout, "mdots %s\n", version)
+		return 0
+	case "push", "pull", "diff":
+		// 宣言ツリーへ進む。
+	default:
+		fmt.Fprintf(stderr, "unknown command: %s\n", args[0])
+		fmt.Fprint(stderr, GlobalHelp)
+		return 1
+	}
+
+	cmd := r.newCommand()
+	r.cmdArgs = args[1:]
+	if err := cmd.Run(context.Background(), append([]string{"mdots"}, args...)); err != nil {
+		var ee *exitError
+		if errors.As(err, &ee) {
+			return ee.code
+		}
+		// 想定外のエラーは文面を出して exit 1（表面の想定経路はすべて exitError）。
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
+
+// targetFlag は --target の宣言である。--target <name> と --target=<name> の
+// 両形式はフレームワークが解釈する。
+func targetFlag() cliv3.Flag {
+	return &cliv3.StringFlag{Name: "target", Usage: "対象Target (例: win, wsl)。--target=<name> 形式も可"}
+}
+
+// dryRunFlag は --dry-run の宣言である。diff では定義した上で拒否し、
+// 凍結文面のエラーメッセージを保つ。
+func dryRunFlag() cliv3.Flag {
+	return &cliv3.BoolFlag{Name: "dry-run", Usage: "実際に書き込まず差分相当を出力する。差分ありは exit 1"}
+}
+
+// newCommand はコマンド宣言ツリーを組み立てる。help文面は凍結値のテンプレートで
+// 上書きし、--target/--dry-run の定義だけをフレームワークに任せる。
+func (r *runner) newCommand() *cliv3.Command {
+	return &cliv3.Command{
+		Name:    "mdots",
+		Usage:   "dotfilesをファイルコピー（非symlink）で管理するCLI。",
+		Version: r.version,
+		// 組み込みの version 表示・help サブコマンドは表面にないため抑止する。
+		// version 表示と unknown 時の扱いは Run の事前振り分けが凍結値で行う。
+		HideVersion:                   true,
+		HideHelpCommand:               true,
+		Suggest:                       false,
+		Writer:                        r.stdout,
+		ErrWriter:                     r.stderr,
+		CustomRootCommandHelpTemplate: GlobalHelp,
+		// 想定外の出力（Incorrect Usage 等）を抑え、文面は自前の凍結値のみにする。
+		ExitErrHandler: func(context.Context, *cliv3.Command, error) {},
+		Action:         r.rootAction,
+		Commands: []*cliv3.Command{
+			{
+				Name:               "push",
+				Usage:              "Storeからdestへファイルをコピーする",
+				CustomHelpTemplate: PushHelp,
+				Flags: []cliv3.Flag{
+					targetFlag(),
+					dryRunFlag(),
+				},
+				OnUsageError: r.usageError(PushHelp),
+				Action:       r.pushAction,
+			},
+			{
+				Name:               "pull",
+				Usage:              "destからStoreへファイルを回収する",
+				CustomHelpTemplate: PullHelp,
+				Flags: []cliv3.Flag{
+					targetFlag(),
+					dryRunFlag(),
+				},
+				OnUsageError: r.usageError(PullHelp),
+				Action:       r.pullAction,
+			},
+			{
+				Name:               "diff",
+				Usage:              "Storeとdestの差分を表示する",
+				CustomHelpTemplate: DiffHelp,
+				Flags: []cliv3.Flag{
+					targetFlag(),
+					// diff では --dry-run を拒否する。未定義にせず定義した上で
+					// 凍結文面で拒否することで、表面のエラーメッセージを保つ。
+					&cliv3.BoolFlag{Name: "dry-run", Usage: "push/pull のみで有効"},
+				},
+				OnUsageError: r.usageError(DiffHelp),
+				Action:       r.diffAction,
+			},
+			{
+				// version サブコマンドの宣言。従来の先頭トークン優先を保つため
+				// Run の事前振り分けが先に処理するが、ツリーの完全性のため宣言を残す。
+				Name:               "version",
+				Usage:              "バージョンを表示する",
+				CustomHelpTemplate: GlobalHelp,
+				SkipFlagParsing:    true,
+				Action: func(context.Context, *cliv3.Command) error {
+					fmt.Fprintf(r.stdout, "mdots %s\n", r.version)
+					return nil
+				},
+			},
+		},
+	}
+}
+
+// rootAction は念のための到達不能ガードである。通常の経路は Run の事前振り分けで
+// 処理されるため、ここに来るのは想定外の呼び出しのみである。
+func (r *runner) rootAction(_ context.Context, cmd *cliv3.Command) error {
+	if cmd.Args().Present() {
+		fmt.Fprintf(r.stderr, "unknown command: %s\n", cmd.Args().First())
+		fmt.Fprint(r.stderr, GlobalHelp)
+		return &exitError{code: 1}
+	}
+	fmt.Fprint(r.stderr, GlobalHelp)
+	return &exitError{code: 1}
+}
+
+// usageError はフラグ解釈失敗時（未知フラグ・--target の値不足）の表面を凍結値で出す。
+//
+// なお従来の自前解析との優先順位の違いは残る。--help と不正トークン
+// （diff での --dry-run を含む）の併用時はフレームワークの help 優先となり、
+// bare `--` はフラグ区切りとして扱う。いずれも exit 1 である点は従来通り。
+func (r *runner) usageError(commandHelp string) cliv3.OnUsageErrorFunc {
+	return func(_ context.Context, _ *cliv3.Command, err error, _ bool) error {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "needs an argument"):
+			// --target の値がない場合。対象フラグは target のみ。
+			msg = "missing value for --target"
+		case strings.HasPrefix(msg, "flag provided but not defined: -"):
+			name := strings.TrimLeft(strings.TrimPrefix(msg, "flag provided but not defined: -"), "-")
+			msg = "unknown argument: " + r.rawFlagToken(name)
+		}
+		fmt.Fprintln(r.stderr, msg)
+		fmt.Fprint(r.stderr, commandHelp)
+		return &exitError{code: 1}
+	}
+}
+
+// rawFlagToken は報告されたフラグ名に対応する元の綴りを生トークンから探す。
+// 見つからなければ --<name> 形式にフォールバックする。
+func (r *runner) rawFlagToken(name string) string {
+	for _, tok := range r.cmdArgs {
+		base := strings.TrimLeft(tok, "-")
+		if i := strings.Index(base, "="); i >= 0 {
+			base = base[:i]
+		}
+		if base == name {
+			return tok
+		}
+	}
+	return "--" + name
+}
+
+// argError は余分な位置引数の表面を凍結値で出す。
+func (r *runner) argError(commandHelp, arg string) error {
+	fmt.Fprintf(r.stderr, "unknown argument: %s\n", arg)
+	fmt.Fprint(r.stderr, commandHelp)
+	return &exitError{code: 1}
+}
+
+func (r *runner) targetOf(cmd *cliv3.Command, commandHelp string) (string, error) {
+	target := cmd.String("target")
+	if cmd.IsSet("target") && target == "" {
+		// --target= のように空値で指定された場合。
+		fmt.Fprintln(r.stderr, "missing value for --target")
+		fmt.Fprint(r.stderr, commandHelp)
+		return "", &exitError{code: 1}
+	}
+	return target, nil
+}
+
+// targetArgs は余分な位置引数の検査と --target の解釈をまとめて行う。
+func (r *runner) targetArgs(cmd *cliv3.Command, commandHelp string) (string, error) {
+	if cmd.Args().Present() {
+		return "", r.argError(commandHelp, cmd.Args().First())
+	}
+	return r.targetOf(cmd, commandHelp)
+}
+
+func (r *runner) pushAction(_ context.Context, cmd *cliv3.Command) error {
+	target, err := r.targetArgs(cmd, PushHelp)
+	if err != nil {
+		return err
+	}
+	if cmd.Bool("dry-run") {
+		if code := r.exec.PushDryRun(r.cwd, target, r.stdout, r.stderr); code != 0 {
+			return &exitError{code: code}
+		}
+		return nil
+	}
+	if err := r.exec.Push(r.cwd, target); err != nil {
+		fmt.Fprintln(r.stderr, err)
+		return &exitError{code: 1}
+	}
+	return nil
+}
+
+func (r *runner) pullAction(_ context.Context, cmd *cliv3.Command) error {
+	target, err := r.targetArgs(cmd, PullHelp)
+	if err != nil {
+		return err
+	}
+	if cmd.Bool("dry-run") {
+		if code := r.exec.PullDryRun(r.cwd, target, r.stdout, r.stderr); code != 0 {
+			return &exitError{code: code}
+		}
+		return nil
+	}
+	if err := r.exec.Pull(r.cwd, target); err != nil {
+		fmt.Fprintln(r.stderr, err)
+		return &exitError{code: 1}
+	}
+	return nil
+}
+
+func (r *runner) diffAction(_ context.Context, cmd *cliv3.Command) error {
+	target, err := r.targetArgs(cmd, DiffHelp)
+	if err != nil {
+		return err
+	}
+	if cmd.Bool("dry-run") {
+		fmt.Fprintln(r.stderr, "--dry-run is only supported for push/pull")
+		fmt.Fprint(r.stderr, DiffHelp)
+		return &exitError{code: 1}
+	}
+	out, hasDiff, err := r.exec.Diff(r.cwd, target)
+	if err != nil {
+		fmt.Fprintln(r.stderr, err)
+		return &exitError{code: 1}
+	}
+	if hasDiff {
+		fmt.Fprint(r.stdout, out)
+		return &exitError{code: 1}
+	}
+	return nil
+}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,264 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// Seam: CLIコマンド境界 (新CLIパッケージ: コマンド定義・Writer注入・exit)
+// 実行系はfake Executorに差し替え、外部挙動（exit codeと出力文面）のみを検証する。
+
+type fakeExecutor struct {
+	pushTarget string
+	pushCalls  int
+	pushErr    error
+
+	pullTarget string
+	pullCalls  int
+	pullErr    error
+
+	diffOut     string
+	diffHasDiff bool
+	diffErr     error
+	diffCalls   int
+
+	pushDryCode  int
+	pushDryOut   string
+	pushDryCalls int
+
+	pullDryCode  int
+	pullDryOut   string
+	pullDryCalls int
+}
+
+func (f *fakeExecutor) Push(cwd, target string) error {
+	f.pushCalls++
+	f.pushTarget = target
+	return f.pushErr
+}
+
+func (f *fakeExecutor) Pull(cwd, target string) error {
+	f.pullCalls++
+	f.pullTarget = target
+	return f.pullErr
+}
+
+func (f *fakeExecutor) Diff(cwd, target string) (string, bool, error) {
+	f.diffCalls++
+	return f.diffOut, f.diffHasDiff, f.diffErr
+}
+
+func (f *fakeExecutor) PushDryRun(cwd, target string, stdout, stderr io.Writer) int {
+	f.pushDryCalls++
+	f.pushTarget = target
+	io.WriteString(stdout, f.pushDryOut)
+	return f.pushDryCode
+}
+
+func (f *fakeExecutor) PullDryRun(cwd, target string, stdout, stderr io.Writer) int {
+	f.pullDryCalls++
+	f.pullTarget = target
+	io.WriteString(stdout, f.pullDryOut)
+	return f.pullDryCode
+}
+
+func runCli(t *testing.T, ex Executor, args []string) (int, string, string) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	code := Run(args, t.TempDir(), "v0.0.0-test", ex, &out, &errOut)
+	return code, out.String(), errOut.String()
+}
+
+func TestCliGlobalHelp(t *testing.T) {
+	for _, args := range [][]string{{"--help"}, {"-h"}} {
+		ex := &fakeExecutor{}
+		code, out, _ := runCli(t, ex, args)
+		if code != 0 {
+			t.Fatalf("Run(%v) exit = %d, want 0", args, code)
+		}
+		for _, want := range []string{"usage:", "push", "pull", "diff"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("Run(%v): output should contain %q, got %q", args, want, out)
+			}
+		}
+	}
+}
+
+func TestCliNoArgsPrintsGlobalHelpToStderr(t *testing.T) {
+	ex := &fakeExecutor{}
+	code, _, errOut := runCli(t, ex, nil)
+	if code != 1 {
+		t.Fatalf("Run(nil) exit = %d, want 1", code)
+	}
+	if !strings.Contains(errOut, "usage:") {
+		t.Errorf("stderr should contain usage:, got %q", errOut)
+	}
+}
+
+func TestCliVersion(t *testing.T) {
+	for _, args := range [][]string{{"--version"}, {"-V"}, {"version"}} {
+		ex := &fakeExecutor{}
+		code, out, _ := runCli(t, ex, args)
+		if code != 0 {
+			t.Fatalf("Run(%v) exit = %d, want 0", args, code)
+		}
+		if !strings.Contains(out, "v0.0.0-test") {
+			t.Errorf("Run(%v): output should contain version, got %q", args, out)
+		}
+	}
+}
+
+func TestCliUnknownCommand(t *testing.T) {
+	ex := &fakeExecutor{}
+	code, _, errOut := runCli(t, ex, []string{"frobnicate"})
+	if code != 1 {
+		t.Fatalf("Run(unknown) exit = %d, want 1", code)
+	}
+	for _, want := range []string{"unknown command: frobnicate", "usage:"} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("stderr should contain %q, got %q", want, errOut)
+		}
+	}
+}
+
+func TestCliCommandHelp(t *testing.T) {
+	tests := []struct {
+		args []string
+		want []string
+	}{
+		{[]string{"push", "--help"}, []string{"push", "--target", "--dry-run"}},
+		{[]string{"push", "-h"}, []string{"push", "--target", "--dry-run"}},
+		{[]string{"pull", "--help"}, []string{"pull", "--target", "--dry-run"}},
+		{[]string{"diff", "--help"}, []string{"diff", "--target"}},
+	}
+	for _, tt := range tests {
+		ex := &fakeExecutor{}
+		code, out, _ := runCli(t, ex, tt.args)
+		if code != 0 {
+			t.Fatalf("Run(%v) exit = %d, want 0", tt.args, code)
+		}
+		for _, want := range tt.want {
+			if !strings.Contains(out, want) {
+				t.Errorf("Run(%v): output should contain %q, got %q", tt.args, want, out)
+			}
+		}
+	}
+}
+
+func TestCliPushDispatchesTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no target", []string{"push"}, ""},
+		{"space form", []string{"push", "--target", "win"}, "win"},
+		{"equals form", []string{"push", "--target=win"}, "win"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ex := &fakeExecutor{}
+			code, _, _ := runCli(t, ex, tt.args)
+			if code != 0 {
+				t.Fatalf("Run(%v) exit = %d, want 0", tt.args, code)
+			}
+			if ex.pushCalls != 1 {
+				t.Fatalf("Push calls = %d, want 1", ex.pushCalls)
+			}
+			if ex.pushTarget != tt.want {
+				t.Errorf("Push target = %q, want %q", ex.pushTarget, tt.want)
+			}
+		})
+	}
+}
+
+func TestCliTargetFlagErrors(t *testing.T) {
+	for _, args := range [][]string{
+		{"push", "--target"},
+		{"push", "--target="},
+		{"push", "--unknown"},
+		{"push", "extra-positional"},
+		{"pull", "--target"},
+		{"pull", "--target="},
+		{"pull", "--unknown"},
+		{"diff", "--target"},
+		{"diff", "--target="},
+		{"diff", "--unknown"},
+	} {
+		ex := &fakeExecutor{}
+		if code, _, _ := runCli(t, ex, args); code == 0 {
+			t.Errorf("Run(%v): exit = 0, want non-zero", args)
+		}
+	}
+}
+
+func TestCliDiffRejectsDryRun(t *testing.T) {
+	ex := &fakeExecutor{}
+	code, _, errOut := runCli(t, ex, []string{"diff", "--dry-run"})
+	if code == 0 {
+		t.Fatal("Run(diff --dry-run): exit = 0, want non-zero")
+	}
+	if !strings.Contains(errOut, "--dry-run is only supported for push/pull") {
+		t.Errorf("stderr should contain dry-run rejection, got %q", errOut)
+	}
+}
+
+func TestCliPushDryRunDelegatesExitCode(t *testing.T) {
+	ex := &fakeExecutor{pushDryCode: 1, pushDryOut: "--- a\n+++ b\n"}
+	code, out, _ := runCli(t, ex, []string{"push", "--dry-run"})
+	if code != 1 {
+		t.Fatalf("Run(push --dry-run) exit = %d, want 1", code)
+	}
+	if ex.pushDryCalls != 1 || ex.pushCalls != 0 {
+		t.Errorf("dry-run must delegate to PushDryRun only (dry=%d push=%d)", ex.pushDryCalls, ex.pushCalls)
+	}
+	if !strings.Contains(out, "---") {
+		t.Errorf("output should contain diff, got %q", out)
+	}
+
+	ex = &fakeExecutor{pushDryCode: 0}
+	if code, _, _ := runCli(t, ex, []string{"push", "--dry-run"}); code != 0 {
+		t.Errorf("Run(push --dry-run) without changes: exit = %d, want 0", code)
+	}
+}
+
+func TestCliPullDryRunDelegatesExitCode(t *testing.T) {
+	ex := &fakeExecutor{pullDryCode: 1, pullDryOut: "--- a\n+++ b\n"}
+	if code, _, _ := runCli(t, ex, []string{"pull", "--dry-run"}); code != 1 {
+		t.Errorf("Run(pull --dry-run) with changes: exit = %d, want 1", code)
+	}
+	ex = &fakeExecutor{pullDryCode: 0}
+	if code, _, _ := runCli(t, ex, []string{"pull", "--dry-run"}); code != 0 {
+		t.Errorf("Run(pull --dry-run) without changes: exit = %d, want 0", code)
+	}
+}
+
+func TestCliDiffExitCode(t *testing.T) {
+	ex := &fakeExecutor{diffOut: "--- a\n+++ b\n", diffHasDiff: true}
+	code, out, _ := runCli(t, ex, []string{"diff"})
+	if code != 1 {
+		t.Errorf("Run(diff) with changes: exit = %d, want 1", code)
+	}
+	if !strings.Contains(out, "---") {
+		t.Errorf("output should contain diff, got %q", out)
+	}
+
+	ex = &fakeExecutor{}
+	if code, _, _ := runCli(t, ex, []string{"diff"}); code != 0 {
+		t.Errorf("Run(diff) without changes: exit = %d, want 0", code)
+	}
+}
+
+func TestCliExecutorErrorExitsNonZero(t *testing.T) {
+	ex := &fakeExecutor{pushErr: errors.New("boom")}
+	code, _, errOut := runCli(t, ex, []string{"push"})
+	if code == 0 {
+		t.Fatal("Run(push) with executor error: exit = 0, want non-zero")
+	}
+	if !strings.Contains(errOut, "boom") {
+		t.Errorf("stderr should contain executor error, got %q", errOut)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/mogurastore/mdots
 
 go 1.27.0
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/urfave/cli/v3 v3.11.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/urfave/cli/v3 v3.11.0 h1:P/euJp99kb9p0tlVY+iYTLYYTAQlfl0hR2gUO1Img1Q=
+github.com/urfave/cli/v3 v3.11.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
+	"github.com/mogurastore/mdots/cli"
 	"github.com/mogurastore/mdots/config"
 	"github.com/mogurastore/mdots/sync"
 )
@@ -24,180 +24,32 @@ func main() {
 	os.Exit(run(os.Args[1:], cwd))
 }
 
-const usage = "usage: mdots <push|pull|diff> [--target <name>]"
-
-const globalHelp = `usage: mdots <push|pull|diff> [options]
-
-dotfilesをファイルコピー（非symlink）で管理するCLI。
-Store（mdots.yaml を含む管理リポジトリのルート）をカレントから親方向に探索する。
-
-commands:
-  push  Storeからdestへファイルをコピーする
-  pull  destからStoreへファイルを回収する
-  diff  Storeとdestの差分を表示する
-
-global options:
-  -h, --help     使い方を表示する
-  --version      バージョンを表示する
-
-run 'mdots <command> --help' for command-specific help.
-`
-
-const pushHelp = `usage: mdots push [--target <name>] [--dry-run]
-
-Storeからdestへファイルをコピーする。
---target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
-
-options:
-  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
-  --dry-run        実際に書き込まず差分相当を出力する。差分ありは exit 1
-  -h, --help       使い方を表示する
-`
-
-const pullHelp = `usage: mdots pull [--target <name>] [--dry-run]
-
-destからStoreへファイルを回収する。
---target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
-
-options:
-  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
-  --dry-run        実際に書き込まず差分相当を出力する。差分ありは exit 1
-  -h, --help       使い方を表示する
-`
-
-const diffHelp = `usage: mdots diff [--target <name>]
-
-Storeとdestの差分を diff -u 風に出力する。
-差分なしは無出力・exit 0、差分ありは差分を出力し exit 1。
---target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
-
-options:
-  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
-  -h, --help       使い方を表示する
-`
-
-func commandHelp(cmd string) string {
-	switch cmd {
-	case "push":
-		return pushHelp
-	case "pull":
-		return pullHelp
-	case "diff":
-		return diffHelp
-	default:
-		return globalHelp
-	}
-}
-
 func run(args []string, cwd string) int {
 	return runWithWriters(args, cwd, os.Stdout, os.Stderr)
 }
 
+// runWithWriters は CLI の薄い入口である。表面の定義は cli パッケージに置き、
+// 内部実行は既存ロジックに委譲する。
 func runWithWriters(args []string, cwd string, stdout, stderr io.Writer) int {
-	if len(args) == 0 {
-		fmt.Fprint(stderr, globalHelp)
-		return 1
-	}
-	switch args[0] {
-	case "--help", "-h":
-		fmt.Fprint(stdout, globalHelp)
-		return 0
-	case "--version", "-V", "version":
-		fmt.Fprintf(stdout, "mdots %s\n", version)
-		return 0
-	}
-	cmd := args[0]
-	if cmd != "push" && cmd != "pull" && cmd != "diff" {
-		fmt.Fprintf(stderr, "unknown command: %s\n", cmd)
-		fmt.Fprint(stderr, globalHelp)
-		return 1
-	}
-	allowDryRun := cmd == "push" || cmd == "pull"
-	opts, err := parseCmdArgs(args[1:], allowDryRun)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		fmt.Fprint(stderr, commandHelp(cmd))
-		return 1
-	}
-	if opts.help {
-		fmt.Fprint(stdout, commandHelp(cmd))
-		return 0
-	}
-	switch cmd {
-	case "push":
-		if opts.dryRun {
-			return runPushDryRun(cwd, opts.target, stdout, stderr)
-		}
-		if err := runPush(cwd, opts.target); err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		return 0
-	case "pull":
-		if opts.dryRun {
-			return runPullDryRun(cwd, opts.target, stdout, stderr)
-		}
-		if err := runPull(cwd, opts.target); err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		return 0
-	case "diff":
-		out, hasDiff, err := runDiff(cwd, opts.target)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if hasDiff {
-			fmt.Fprint(stdout, out)
-			return 1
-		}
-		return 0
-	}
-	return 1
+	return cli.Run(args, cwd, version, cliExecutor{}, stdout, stderr)
 }
 
-// cmdOptions は push/pull/diff のコマンドフラグを表す。
-type cmdOptions struct {
-	target string
-	dryRun bool
-	help   bool
+// cliExecutor は cli.Executor への委譲口である。実行系の本体は本ファイルの
+// runPush/runPull/runDiff 系に残し、コマンド骨格だけを cli パッケージに置く。
+type cliExecutor struct{}
+
+func (cliExecutor) Push(cwd, target string) error { return runPush(cwd, target) }
+
+func (cliExecutor) Pull(cwd, target string) error { return runPull(cwd, target) }
+
+func (cliExecutor) Diff(cwd, target string) (string, bool, error) { return runDiff(cwd, target) }
+
+func (cliExecutor) PushDryRun(cwd, target string, stdout, stderr io.Writer) int {
+	return runPushDryRun(cwd, target, stdout, stderr)
 }
 
-// parseCmdArgs は push/pull/diff のフラグを解釈する。
-// `--target <name>` と `--target=<name>`、`--dry-run`、`-h/--help` を受け付ける。
-// diff では --dry-run を拒否する (allowDryRun=false)。
-func parseCmdArgs(args []string, allowDryRun bool) (cmdOptions, error) {
-	var opts cmdOptions
-	seen := false
-	for i := 0; i < len(args); i++ {
-		a := args[i]
-		switch {
-		case a == "--target":
-			if i+1 >= len(args) {
-				return cmdOptions{}, fmt.Errorf("missing value for --target")
-			}
-			opts.target = args[i+1]
-			i++
-			seen = true
-		case strings.HasPrefix(a, "--target="):
-			opts.target = strings.TrimPrefix(a, "--target=")
-			seen = true
-		case a == "--dry-run":
-			if !allowDryRun {
-				return cmdOptions{}, fmt.Errorf("--dry-run is only supported for push/pull")
-			}
-			opts.dryRun = true
-		case a == "--help" || a == "-h":
-			opts.help = true
-		default:
-			return cmdOptions{}, fmt.Errorf("unknown argument: %s", a)
-		}
-	}
-	if seen && opts.target == "" {
-		return cmdOptions{}, fmt.Errorf("missing value for --target")
-	}
-	return opts, nil
+func (cliExecutor) PullDryRun(cwd, target string, stdout, stderr io.Writer) int {
+	return runPullDryRun(cwd, target, stdout, stderr)
 }
 
 // resolveEntries は Store 発見・設定読込・Target フィルタをまとめて行い、


### PR DESCRIPTION
# CLI骨格をurfave/cli v3に置換し表面同等にする

Closes #25.

## 概要

CLI表面を変えずにコマンド骨格を urfave/cli v3 の宣言ツリーに置換する。
内部実行は既存ロジック委譲、エントリは薄く保ち定義は新 `cli` パッケージに置く。

## 変更点

- 新 `cli` パッケージ: push/pull/diff と `--target`/`--dry-run` の宣言ツリー、凍結 help 文面、`Executor` 委譲口
- `main.go` 薄化: 自前フラグ解析・help 重複を削除し `cli.Run` 委譲＋`cliExecutor` 適合のみ残す
- `cli` パッケージ doc に最終採用 v3・pflag のみ予備案の扱いを記録（#24 の決定通り）
- `cli/cli_test.go` 追加: fake Executor による CLI 境界テスト

## 検証

- `go vet ./...`、`gofmt` clean、`go test -count=1 ./...` 全 green
- 新旧バイナリ差分テスト58件中56件が stdout/stderr/exit バイト一致。残り2件（`push --help extra`、`push -- --target`）は exit 一致の病的コーナーでコード内コメントに明示
- `/code-review` の Standards/Spec 両軸を実施済み
