### PR TITLE
feat: Store発見をカレント直下のみに狭める

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,7 +5,7 @@ dotfilesをファイルコピー（非symlink）で管理するCLI。Store（管
 ## Language
 
 **Store**:
-mdots.yaml を含む管理リポジトリのルート。カレントから親方向に探索して発見される。
+mdots.yaml を含む管理リポジトリのルート。カレント直下のmdots.yamlのみ参照する。
 _Avoid_: repo, dotfiles repo
 
 **Entry**:

--- a/README.md
+++ b/README.md
@@ -64,5 +64,5 @@ mdots --version         # バージョンを表示する（ldflags -X main.versi
 
 - `--target` 未指定時は common のみ、指定時は common + 指定 Target が対象になる。
 - `--dry-run` は実際に書き込まず差分相当を出力する。差分ありは exit 1、差分なしは exit 0。
-- `mdots.yaml` が見つからないときは `mdots.yaml not found: searched from <cwd> to /` と表示し exit 1 になる。
-- Store はカレントから親方向に `mdots.yaml` を探索して発見する。サブディレクトリからでも実行できる。
+- `mdots.yaml` が見つからないときは `mdots.yaml not found in <cwd>` と表示し exit 1 になる。
+- Store はカレント直下の `mdots.yaml` のみ参照する。Store直下で実行し、サブディレクトリからは実行できない。

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -22,7 +22,7 @@ import (
 const GlobalHelp = `usage: mdots <push|pull|diff> [options]
 
 dotfilesをファイルコピー（非symlink）で管理するCLI。
-Store（mdots.yaml を含む管理リポジトリのルート）をカレントから親方向に探索する。
+Store（mdots.yaml を含む管理リポジトリのルート）の直下で実行する。mdots.yaml はカレント直下のみ参照する。
 
 commands:
   push  Storeからdestへファイルをコピーする

--- a/cli_test.go
+++ b/cli_test.go
@@ -194,7 +194,7 @@ func TestStoreNotFoundFriendlyError(t *testing.T) {
 	if code := runWithWriters([]string{"push"}, empty, &out, &errOut); code == 0 {
 		t.Fatal("run(push) without Store: exit = 0, want non-zero")
 	}
-	if !strings.Contains(errOut.String(), "mdots.yaml not found: searched from ") {
+	if !strings.Contains(errOut.String(), "mdots.yaml not found in "+empty) {
 		t.Errorf("stderr should contain friendly message, got %q", errOut.String())
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -147,22 +147,15 @@ func (e Entry) ExpandedDest() (string, error) {
 	return ExpandDest(e.Dest)
 }
 
-// FindStore は開始ディレクトリから親方向に mdots.yaml を探索し、
-// 見つかった Store ルートを返す。見つからないときは明確なエラーを返す。
+// FindStore はカレント直下の mdots.yaml のみを参照し、
+// 見つかった Store ルートを返す。見つからないときは in <cwd> 形式のエラーを返す。
 func FindStore(startDir string) (string, error) {
 	abs, err := filepath.Abs(startDir)
 	if err != nil {
 		return "", err
 	}
-	orig := abs
-	for {
-		if _, err := os.Stat(filepath.Join(abs, "mdots.yaml")); err == nil {
-			return abs, nil
-		}
-		parent := filepath.Dir(abs)
-		if parent == abs {
-			return "", fmt.Errorf("mdots.yaml not found: searched from %s to /", orig)
-		}
-		abs = parent
+	if _, err := os.Stat(filepath.Join(abs, "mdots.yaml")); err == nil {
+		return abs, nil
 	}
+	return "", fmt.Errorf("mdots.yaml not found in %s", abs)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,18 +112,14 @@ func TestExpandDest(t *testing.T) {
 }
 
 // Seam: config パッケージ公開境界 (Store 発見)
-// カレントから親方向への mdots.yaml 探索を t.TempDir() の実FSで検証する。
+// カレント直下の mdots.yaml のみを参照する外部挙動を t.TempDir() の実FSで検証する。
 func TestFindStore(t *testing.T) {
-	t.Run("親方向にStoreを発見できる", func(t *testing.T) {
+	t.Run("カレント直下のStoreを発見できる", func(t *testing.T) {
 		root := t.TempDir()
 		if err := os.WriteFile(filepath.Join(root, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		sub := filepath.Join(root, "a", "b")
-		if err := os.MkdirAll(sub, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		got, err := FindStore(sub)
+		got, err := FindStore(root)
 		if err != nil {
 			t.Fatalf("FindStore error: %v", err)
 		}
@@ -132,20 +128,35 @@ func TestFindStore(t *testing.T) {
 		}
 	})
 
-	t.Run("見つからないときは明確なエラー", func(t *testing.T) {
+	t.Run("サブディレクトリからは失敗しin形式のエラー", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		sub := filepath.Join(root, "a", "b")
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		_, err := FindStore(sub)
+		if err == nil {
+			t.Fatal("エラー expected, got nil")
+		}
+		if !strings.Contains(err.Error(), "mdots.yaml not found in "+sub) {
+			t.Errorf("エラーメッセージ不正: got %q, want contain %q", err.Error(), "mdots.yaml not found in "+sub)
+		}
+	})
+
+	t.Run("見つからないときはin形式のエラー", func(t *testing.T) {
 		start := t.TempDir()
 		_, err := FindStore(start)
 		if err == nil {
 			t.Fatal("エラー expected, got nil")
 		}
-		if !strings.HasPrefix(err.Error(), "mdots.yaml not found: searched from ") {
-			t.Errorf("エラーメッセージのprefix不正: got %q", err.Error())
+		if !strings.Contains(err.Error(), "mdots.yaml not found in "+start) {
+			t.Errorf("エラーメッセージ不正: got %q, want contain %q", err.Error(), "mdots.yaml not found in "+start)
 		}
-		if !strings.HasSuffix(err.Error(), " to /") {
-			t.Errorf("エラーメッセージのsuffix不正: got %q", err.Error())
-		}
-		if !strings.Contains(err.Error(), start) {
-			t.Errorf("エラーに探索起点が含まれない: got %q, want contain %q", err.Error(), start)
+		if strings.Contains(err.Error(), "searched from") {
+			t.Errorf("旧文言が残っている: got %q", err.Error())
 		}
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,7 @@ func TestPushEndToEnd(t *testing.T) {
 	}
 }
 
-func TestPushFromSubdirFindsStore(t *testing.T) {
+func TestPushFromSubdirFails(t *testing.T) {
 	store := t.TempDir()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -51,11 +51,11 @@ func TestPushFromSubdirFindsStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if code := run([]string{"push"}, sub); code != 0 {
-		t.Fatalf("run(push) from subdir exit = %d, want 0", code)
+	if code := run([]string{"push"}, sub); code == 0 {
+		t.Fatal("run(push) from subdir exit = 0, want non-zero")
 	}
-	if _, err := os.Stat(filepath.Join(home, ".vimrc")); err != nil {
-		t.Errorf("dest not created from subdir: %v", err)
+	if _, err := os.Stat(filepath.Join(home, ".vimrc")); err == nil {
+		t.Error("dest must NOT be created from subdir")
 	}
 }
 


### PR DESCRIPTION
Closes #26

## 変更内容
- `config.FindStore` をカレント直下の `mdots.yaml` のみ参照に狭小化。親方向探索を廃止
- not foundエラーを `mdots.yaml not found in <cwd>` 形式に変更（`searched from ... to /` を廃止）
- 利用説明（README）・用語集（CONTEXT.md Store定義）・コマンドhelp（GlobalHelp）を新仕様に更新

## テスト
- `config` 境界テストを新仕様に更新（カレント成功・サブディレクトリ失敗・in形式検証）: `go test ./config/ -v` green
- e2e更新: `TestPushFromSubdirFindsStore` → `TestPushFromSubdirFails`、`TestStoreNotFoundFriendlyError` をin形式に
- `go vet ./...` clean、`go test ./...` 全green