### PR TITLE
refactor: 実行系を薄化し差分コアを一本化する

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,24 +66,26 @@ func resolveEntries(cwd string, target string) (string, []config.Entry, error) {
 	return store, config.FilterByTarget(cfg.Entries, target), nil
 }
 
-// runPush は common + 指定Target の Entry を Store から dest へコピーする。
-// target 未指定時は common のみが対象になる。
-func runPush(cwd string, target string) error {
+// runCopy は push/pull のコピー系の共有本体である。方向の違いは copyFn に寄せ、
+// 各 action（runPush/runPull）は薄い委譲に留める。
+func runCopy(cwd string, target string, copyFn func(string, []config.Entry) error) error {
 	store, entries, err := resolveEntries(cwd, target)
 	if err != nil {
 		return err
 	}
-	return sync.Push(store, entries)
+	return copyFn(store, entries)
+}
+
+// runPush は common + 指定Target の Entry を Store から dest へコピーする。
+// target 未指定時は common のみが対象になる。
+func runPush(cwd string, target string) error {
+	return runCopy(cwd, target, sync.Push)
 }
 
 // runPull は common + 指定Target の Entry を dest から Store へ回収する。
 // target 未指定時は common のみが対象になる。
 func runPull(cwd string, target string) error {
-	store, entries, err := resolveEntries(cwd, target)
-	if err != nil {
-		return err
-	}
-	return sync.Pull(store, entries)
+	return runCopy(cwd, target, sync.Pull)
 }
 
 // runDiff は common + 指定Target の Entry について Store/src と dest の
@@ -97,19 +99,8 @@ func runDiff(cwd string, target string) (string, bool, error) {
 	return sync.Diff(store, entries)
 }
 
-// runPushDryRun は push の差分相当を stdout に出し、書き込みは行わない。
-// 差分ありは exit 1、差分なしは exit 0。
-func runPushDryRun(cwd string, target string, stdout, stderr io.Writer) int {
-	store, entries, err := resolveEntries(cwd, target)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	out, hasDiff, err := sync.DryRunPush(store, entries)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
+// emitDiff は差分出力と exit 対応を一本化する。差分ありは出力して 1、なしは 0。
+func emitDiff(stdout io.Writer, out string, hasDiff bool) int {
 	if hasDiff {
 		fmt.Fprint(stdout, out)
 		return 1
@@ -117,22 +108,30 @@ func runPushDryRun(cwd string, target string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-// runPullDryRun は pull の差分相当を stdout に出し、書き込みは行わない。
-// 差分ありは exit 1、差分なしは exit 0。
-func runPullDryRun(cwd string, target string, stdout, stderr io.Writer) int {
+// runDryRun は dry-run 系の共有本体である。欠落時ポリシーの違いは diffFn に寄せ、
+// pushかpullかの分岐は各 action（runPushDryRun/runPullDryRun）の呼び出し側に残す。
+func runDryRun(cwd string, target string, stdout, stderr io.Writer, diffFn func(string, []config.Entry) (string, bool, error)) int {
 	store, entries, err := resolveEntries(cwd, target)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
-	out, hasDiff, err := sync.DryRunPull(store, entries)
+	out, hasDiff, err := diffFn(store, entries)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
-	if hasDiff {
-		fmt.Fprint(stdout, out)
-		return 1
-	}
-	return 0
+	return emitDiff(stdout, out, hasDiff)
+}
+
+// runPushDryRun は push の差分相当を stdout に出し、書き込みは行わない。
+// 差分ありは exit 1、差分なしは exit 0。
+func runPushDryRun(cwd string, target string, stdout, stderr io.Writer) int {
+	return runDryRun(cwd, target, stdout, stderr, sync.DryRunPush)
+}
+
+// runPullDryRun は pull の差分相当を stdout に出し、書き込みは行わない。
+// 差分ありは exit 1、差分なしは exit 0。
+func runPullDryRun(cwd string, target string, stdout, stderr io.Writer) int {
+	return runDryRun(cwd, target, stdout, stderr, sync.DryRunPull)
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -31,17 +31,113 @@ func Push(storeRoot string, entries []config.Entry) error {
 // Diff は Store の src と dest の差分を diff -u 風の文字列で返す。
 // 差分がない Entry は出力に含めない。差分が1件でもあれば hasDiff=true。
 // src/dest が不在・ディレクトリの場合はエラーで中断する。
+// 実体は単一の差分コア（欠落時ポリシーのみ引数化）への薄い委譲である。
 func Diff(storeRoot string, entries []config.Entry) (output string, hasDiff bool, err error) {
+	return diffCore(storeRoot, entries, policyStrict)
+}
+
+// missingPolicy は差分コアにおける欠落時の扱いを表す。
+// 出力・exitの振る舞いは変えず、欠落時ポリシーの違いのみを引数化する。
+type missingPolicy int
+
+const (
+	// policyStrict は Diff 用：src/dest のいずれの欠落もエラーにする。
+	policyStrict missingPolicy = iota
+	// policyPushDryRun は push の dry-run 用：dest 不在を新規作成予定として報告する。
+	policyPushDryRun
+	// policyPullDryRun は pull の dry-run 用：Store の src 不在を新規回収予定として報告する。
+	policyPullDryRun
+)
+
+// opLabel は差分コアのエラー接頭辞をポリシーから導く。
+// 従来の Diff/dry-run の文面をそのまま保つ。
+func (p missingPolicy) opLabel() string {
+	switch p {
+	case policyPushDryRun:
+		return "dry-run push"
+	case policyPullDryRun:
+		return "dry-run pull"
+	default:
+		return "diff"
+	}
+}
+
+// writeNewFileNotice は欠落時の新規作成予定報告を一本化する。文面自体は従来通り。
+func writeNewFileNotice(sb *strings.Builder, srcLabel, destLabel, body string) {
+	sb.WriteString("--- " + srcLabel + "\n")
+	sb.WriteString("+++ " + destLabel + "\n")
+	sb.WriteString(body)
+}
+
+// diffCore は dry-run 系と Diff の単一の差分コアである。
+// 両方存在する Entry は unified diff を出し、不在の扱いだけを policy で切り替える。
+// 自前の unified diff 実装・出力文面・exitの対応（hasDiff）は変えない。
+func diffCore(storeRoot string, entries []config.Entry, policy missingPolicy) (string, bool, error) {
+	op := policy.opLabel()
 	var sb strings.Builder
+	hasDiff := false
 	for _, e := range entries {
 		destPath, err := config.ExpandDest(e.Dest)
 		if err != nil {
-			return "", false, fmt.Errorf("diff %s: dest expand: %w", e.Src, err)
+			return "", false, fmt.Errorf("%s %s: dest expand: %w", op, e.Src, err)
 		}
 		srcPath := filepath.Join(storeRoot, e.Src)
-		d, same, err := diffFile(srcPath, destPath, e.Src, e.Dest)
+		srcInfo, srcErr := os.Stat(srcPath)
+		destInfo, destErr := os.Stat(destPath)
+		switch policy {
+		case policyPushDryRun:
+			if srcErr != nil {
+				return "", false, fmt.Errorf("%s %s: %w", op, e.Src, srcErr)
+			}
+			if srcInfo.IsDir() {
+				return "", false, fmt.Errorf("%s %s: src is a directory: %s", op, e.Src, srcPath)
+			}
+			if destErr != nil {
+				if !os.IsNotExist(destErr) {
+					return "", false, fmt.Errorf("%s %s: %w", op, e.Src, destErr)
+				}
+				writeNewFileNotice(&sb, e.Src, e.Dest, "(new file: "+e.Dest+" would be created)\n")
+				hasDiff = true
+				continue
+			}
+			if destInfo.IsDir() {
+				return "", false, fmt.Errorf("%s %s: dest is a directory: %s", op, e.Src, destPath)
+			}
+		case policyPullDryRun:
+			if destErr != nil {
+				return "", false, fmt.Errorf("%s %s: %w", op, e.Src, destErr)
+			}
+			if destInfo.IsDir() {
+				return "", false, fmt.Errorf("%s %s: dest is a directory: %s", op, e.Src, destPath)
+			}
+			if srcErr != nil {
+				if !os.IsNotExist(srcErr) {
+					return "", false, fmt.Errorf("%s %s: %w", op, e.Src, srcErr)
+				}
+				writeNewFileNotice(&sb, e.Src, e.Dest, "(new file: "+e.Src+" would be created in Store)\n")
+				hasDiff = true
+				continue
+			}
+			if srcInfo.IsDir() {
+				return "", false, fmt.Errorf("%s %s: Store src is a directory: %s", op, e.Src, srcPath)
+			}
+		default:
+			if srcErr != nil {
+				return "", false, fmt.Errorf("%s %s: %w", op, e.Src, srcErr)
+			}
+			if srcInfo.IsDir() {
+				return "", false, fmt.Errorf("%s %s: src is a directory: %s", op, e.Src, srcPath)
+			}
+			if destErr != nil {
+				return "", false, fmt.Errorf("%s %s: %w", op, e.Src, destErr)
+			}
+			if destInfo.IsDir() {
+				return "", false, fmt.Errorf("%s %s: dest is a directory: %s", op, e.Src, destPath)
+			}
+		}
+		d, same, err := diffContent(srcPath, destPath, e.Src, e.Dest)
 		if err != nil {
-			return "", false, fmt.Errorf("diff %s: %w", e.Src, err)
+			return "", false, fmt.Errorf("%s %s: %w", op, e.Src, err)
 		}
 		if !same {
 			sb.WriteString(d)
@@ -51,22 +147,9 @@ func Diff(storeRoot string, entries []config.Entry) (output string, hasDiff bool
 	return sb.String(), hasDiff, nil
 }
 
-// diffFile は2ファイルの unified diff を返す。同一内容なら same=true。
-func diffFile(srcPath, destPath, srcLabel, destLabel string) (diffText string, same bool, err error) {
-	srcInfo, err := os.Stat(srcPath)
-	if err != nil {
-		return "", false, err
-	}
-	if srcInfo.IsDir() {
-		return "", false, fmt.Errorf("src is a directory: %s", srcPath)
-	}
-	destInfo, err := os.Stat(destPath)
-	if err != nil {
-		return "", false, err
-	}
-	if destInfo.IsDir() {
-		return "", false, fmt.Errorf("dest is a directory: %s", destPath)
-	}
+// diffContent は存在確認済みの2ファイルの unified diff を返す。同一内容なら same=true。
+// stat は呼び出し側の差分コアで済ませているため、ここでは読み込みと比較のみ行う。
+func diffContent(srcPath, destPath, srcLabel, destLabel string) (diffText string, same bool, err error) {
 	srcData, err := os.ReadFile(srcPath)
 	if err != nil {
 		return "", false, err
@@ -147,79 +230,18 @@ func unifiedBody(srcLines, destLines []string) string {
 // 両方存在する Entry は Diff と同じ unified diff を出し、
 // dest 不在の Entry は新規作成予定として報告する。
 // src 不在・ディレクトリは push と同様にエラーで中断する。
+// 実体は単一の差分コアへの薄い委譲である。
 func DryRunPush(storeRoot string, entries []config.Entry) (output string, hasDiff bool, err error) {
-	return dryRun(storeRoot, entries, "push")
+	return diffCore(storeRoot, entries, policyPushDryRun)
 }
 
 // DryRunPull は pull の差分相当を返す。実際の書き込みは行わない。
 // 両方存在する Entry は Diff と同じ unified diff を出し、
 // Store の src 不在の Entry は新規回収予定として報告する。
 // dest 不在・ディレクトリは pull と同様にエラーで中断する。
+// 実体は単一の差分コアへの薄い委譲である。
 func DryRunPull(storeRoot string, entries []config.Entry) (output string, hasDiff bool, err error) {
-	return dryRun(storeRoot, entries, "pull")
-}
-
-// dryRun は direction ("push"/"pull") に応じた欠落時の扱いで差分相当を作る。
-func dryRun(storeRoot string, entries []config.Entry, direction string) (string, bool, error) {
-	var sb strings.Builder
-	hasDiff := false
-	for _, e := range entries {
-		destPath, err := config.ExpandDest(e.Dest)
-		if err != nil {
-			return "", false, fmt.Errorf("dry-run %s %s: dest expand: %w", direction, e.Src, err)
-		}
-		srcPath := filepath.Join(storeRoot, e.Src)
-		if direction == "push" {
-			srcInfo, err := os.Stat(srcPath)
-			if err != nil {
-				return "", false, fmt.Errorf("dry-run push %s: %w", e.Src, err)
-			}
-			if srcInfo.IsDir() {
-				return "", false, fmt.Errorf("dry-run push %s: src is a directory: %s", e.Src, srcPath)
-			}
-			if destInfo, err := os.Stat(destPath); err != nil {
-				if !os.IsNotExist(err) {
-					return "", false, fmt.Errorf("dry-run push %s: %w", e.Src, err)
-				}
-				sb.WriteString("--- " + e.Src + "\n")
-				sb.WriteString("+++ " + e.Dest + "\n")
-				sb.WriteString("(new file: " + e.Dest + " would be created)\n")
-				hasDiff = true
-				continue
-			} else if destInfo.IsDir() {
-				return "", false, fmt.Errorf("dry-run push %s: dest is a directory: %s", e.Src, destPath)
-			}
-		} else {
-			destInfo, err := os.Stat(destPath)
-			if err != nil {
-				return "", false, fmt.Errorf("dry-run pull %s: %w", e.Src, err)
-			}
-			if destInfo.IsDir() {
-				return "", false, fmt.Errorf("dry-run pull %s: dest is a directory: %s", e.Src, destPath)
-			}
-			if srcInfo, err := os.Stat(srcPath); err != nil {
-				if !os.IsNotExist(err) {
-					return "", false, fmt.Errorf("dry-run pull %s: %w", e.Src, err)
-				}
-				sb.WriteString("--- " + e.Src + "\n")
-				sb.WriteString("+++ " + e.Dest + "\n")
-				sb.WriteString("(new file: " + e.Src + " would be created in Store)\n")
-				hasDiff = true
-				continue
-			} else if srcInfo.IsDir() {
-				return "", false, fmt.Errorf("dry-run pull %s: Store src is a directory: %s", e.Src, srcPath)
-			}
-		}
-		d, same, err := diffFile(srcPath, destPath, e.Src, e.Dest)
-		if err != nil {
-			return "", false, fmt.Errorf("dry-run %s %s: %w", direction, e.Src, err)
-		}
-		if !same {
-			sb.WriteString(d)
-			hasDiff = true
-		}
-	}
-	return sb.String(), hasDiff, nil
+	return diffCore(storeRoot, entries, policyPullDryRun)
 }
 
 // Pull は dest を Store の src へファイルコピーする。


### PR DESCRIPTION
Closes #27

## 概要

- sync に単一の差分コア diffCore（欠落時ポリシーのみ引数化）を新設し、Diff / DryRunPush / DryRunPull を薄い委譲に統合。旧 dryRun(direction) と diffFile の重複を除去
- main の実行系を薄化。runPush/runPull を runCopy に、runPushDryRun/runPullDryRun を runDryRun + emitDiff に集約。方向選択は各 action 側に残す
- 自前 unified diff・出力文面・exit の振る舞い・version 系・unknown 時表示は不変

## 検証

- go vet clean
- go test ./... green（同期モジュール境界テスト含む）
- code-review 実施済み（Standards 指摘のコミット文言を反映、Spec 指摘なし）