### PR TITLE
test: テスト重複を整理する

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -8,180 +8,66 @@ import (
 	"testing"
 )
 
-// Seam: CLIコマンド境界 (mdots --help / --version)
-// 実FSは使わず、外部挙動（exit codeと出力文面）のみを検証する。
-func TestGlobalHelp(t *testing.T) {
-	var out, errOut bytes.Buffer
-	if code := runWithWriters([]string{"--help"}, t.TempDir(), &out, &errOut); code != 0 {
-		t.Fatalf("run(--help) exit = %d, want 0", code)
-	}
-	got := out.String()
-	for _, want := range []string{"usage:", "push", "pull", "diff"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("help output should contain %q, got %q", want, got)
-		}
-	}
-}
-
-func TestGlobalHelpShortFlag(t *testing.T) {
-	var out, errOut bytes.Buffer
-	if code := runWithWriters([]string{"-h"}, t.TempDir(), &out, &errOut); code != 0 {
-		t.Fatalf("run(-h) exit = %d, want 0", code)
-	}
-	if !strings.Contains(out.String(), "usage:") {
-		t.Errorf("help output should contain usage:, got %q", out.String())
-	}
-}
-
-func TestPushHelp(t *testing.T) {
-	for _, args := range [][]string{{"push", "--help"}, {"push", "-h"}} {
-		var out, errOut bytes.Buffer
-		store := t.TempDir()
-		if code := runWithWriters(args, store, &out, &errOut); code != 0 {
-			t.Fatalf("run(%v) exit = %d, want 0", args, code)
-		}
-		got := out.String()
-		for _, want := range []string{"push", "--target", "--dry-run"} {
-			if !strings.Contains(got, want) {
-				t.Errorf("run(%v): output should contain %q, got %q", args, want, got)
-			}
-		}
-	}
-}
-
-func TestPullHelp(t *testing.T) {
-	var out, errOut bytes.Buffer
-	if code := runWithWriters([]string{"pull", "--help"}, t.TempDir(), &out, &errOut); code != 0 {
-		t.Fatalf("run(pull --help) exit = %d, want 0", code)
-	}
-	for _, want := range []string{"pull", "--target", "--dry-run"} {
-		if !strings.Contains(out.String(), want) {
-			t.Errorf("output should contain %q, got %q", want, out.String())
-		}
-	}
-}
-
-func TestDiffHelp(t *testing.T) {
-	var out, errOut bytes.Buffer
-	if code := runWithWriters([]string{"diff", "--help"}, t.TempDir(), &out, &errOut); code != 0 {
-		t.Fatalf("run(diff --help) exit = %d, want 0", code)
-	}
-	for _, want := range []string{"diff", "--target"} {
-		if !strings.Contains(out.String(), want) {
-			t.Errorf("output should contain %q, got %q", want, out.String())
-		}
-	}
-}
-
-func TestVersion(t *testing.T) {
-	old := version
-	version = "v0.0.0-test"
-	defer func() { version = old }()
-
-	var out, errOut bytes.Buffer
-	if code := runWithWriters([]string{"--version"}, t.TempDir(), &out, &errOut); code != 0 {
-		t.Fatalf("run(--version) exit = %d, want 0", code)
-	}
-	if !strings.Contains(out.String(), "v0.0.0-test") {
-		t.Errorf("version output should contain %q, got %q", "v0.0.0-test", out.String())
-	}
-}
-
-// Seam: CLIコマンド境界 (mdots push/pull --dry-run)
+// Seam: CLIコマンド境界 (mdots push/pull --dry-run の代表例)
 // 実FS上の Store/dest を用い、書き込みなし・差分相当出力の外部挙動のみを検証する。
-func TestPushDryRunDoesNotWriteButShowsDiff(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+// help/version・フラグ解釈・exit 委譲は新CLIパッケージ境界テストに寄せ、
+// 差分詳細は同期境界テストに寄せる。Store 準備・HOME 隔離は main_test.go の
+// setupStoreWithHome に集約している。
+func TestDryRunIntegration(t *testing.T) {
+	t.Run("pushは差分を出して書き込まない", func(t *testing.T) {
+		store, home := setupStoreWithHome(t,
+			map[string]string{"vimrc": "new\n"},
+			map[string]string{".vimrc": "old\n"},
+			"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+		)
 
-	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("new\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("old\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+		var out, errOut bytes.Buffer
+		if code := runWithWriters([]string{"push", "--dry-run"}, store, &out, &errOut); code == 0 {
+			t.Error("run(push --dry-run) with changes: exit = 0, want non-zero")
+		}
+		if !strings.Contains(out.String(), "---") || !strings.Contains(out.String(), "+++") {
+			t.Errorf("dry-run output should contain ---/+++, got %q", out.String())
+		}
+		if got, err := os.ReadFile(filepath.Join(home, ".vimrc")); err != nil || string(got) != "old\n" {
+			t.Errorf("dest must NOT be written on dry-run: content = %q err = %v", got, err)
+		}
+	})
 
-	var out, errOut bytes.Buffer
-	code := runWithWriters([]string{"push", "--dry-run"}, store, &out, &errOut)
-	if code == 0 {
-		t.Error("run(push --dry-run) with changes: exit = 0, want non-zero")
-	}
-	if !strings.Contains(out.String(), "---") || !strings.Contains(out.String(), "+++") {
-		t.Errorf("dry-run output should contain ---/+++, got %q", out.String())
-	}
-	got, err := os.ReadFile(filepath.Join(home, ".vimrc"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "old\n" {
-		t.Errorf("dest must NOT be written on dry-run: content = %q, want %q", got, "old\n")
-	}
-}
+	t.Run("pullは差分を出して書き込まない", func(t *testing.T) {
+		store, _ := setupStoreWithHome(t,
+			map[string]string{"vimrc": "old\n"},
+			map[string]string{".vimrc": "new\n"},
+			"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+		)
 
-func TestPushDryRunNoDiffExitsZero(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+		var out, errOut bytes.Buffer
+		if code := runWithWriters([]string{"pull", "--dry-run"}, store, &out, &errOut); code == 0 {
+			t.Error("run(pull --dry-run) with changes: exit = 0, want non-zero")
+		}
+		if !strings.Contains(out.String(), "---") || !strings.Contains(out.String(), "+++") {
+			t.Errorf("dry-run output should contain ---/+++, got %q", out.String())
+		}
+		if got, err := os.ReadFile(filepath.Join(store, "vimrc")); err != nil || string(got) != "old\n" {
+			t.Errorf("Store must NOT be written on dry-run: content = %q err = %v", got, err)
+		}
+	})
 
-	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("same\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("same\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	t.Run("差分なしはexit 0", func(t *testing.T) {
+		store, _ := setupStoreWithHome(t,
+			map[string]string{"vimrc": "same\n"},
+			map[string]string{".vimrc": "same\n"},
+			"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+		)
 
-	var out, errOut bytes.Buffer
-	if code := runWithWriters([]string{"push", "--dry-run"}, store, &out, &errOut); code != 0 {
-		t.Errorf("run(push --dry-run) without changes: exit = %d, want 0", code)
-	}
-}
-
-func TestPullDryRunDoesNotWriteButShowsDiff(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("old\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("new\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	var out, errOut bytes.Buffer
-	code := runWithWriters([]string{"pull", "--dry-run"}, store, &out, &errOut)
-	if code == 0 {
-		t.Error("run(pull --dry-run) with changes: exit = 0, want non-zero")
-	}
-	if !strings.Contains(out.String(), "---") || !strings.Contains(out.String(), "+++") {
-		t.Errorf("dry-run output should contain ---/+++, got %q", out.String())
-	}
-	got, err := os.ReadFile(filepath.Join(store, "vimrc"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "old\n" {
-		t.Errorf("Store must NOT be written on dry-run: content = %q, want %q", got, "old\n")
-	}
+		var out, errOut bytes.Buffer
+		if code := runWithWriters([]string{"push", "--dry-run"}, store, &out, &errOut); code != 0 {
+			t.Errorf("run(push --dry-run) without changes: exit = %d, want 0", code)
+		}
+	})
 }
 
 func TestDiffRejectsDryRun(t *testing.T) {
-	store := t.TempDir()
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	store, _ := setupStoreWithHome(t, nil, nil, "entries: []\n")
 	var out, errOut bytes.Buffer
 	if code := runWithWriters([]string{"diff", "--dry-run"}, store, &out, &errOut); code == 0 {
 		t.Error("run(diff --dry-run): exit = 0, want non-zero")

--- a/main_test.go
+++ b/main_test.go
@@ -3,24 +3,43 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-// Seam: CLIコマンド境界 (mdots push)
-// 実FS上の Store/dest を用い、end-to-end の外部挙動のみを検証する。
-func TestPushEndToEnd(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
+// setupStoreWithHome は Store 準備・HOME 隔離の定型を集約する。
+// storeFiles は Store 直下に作るファイル群、homeFiles は HOME 直下に作る
+// ファイル群、yaml は mdots.yaml の本文。HOME は t.Setenv で隔離する。
+func setupStoreWithHome(t *testing.T, storeFiles, homeFiles map[string]string, yaml string) (store, home string) {
+	t.Helper()
+	store = t.TempDir()
+	home = t.TempDir()
 	t.Setenv("HOME", home)
-
-	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("set number\n"), 0o644); err != nil {
-		t.Fatal(err)
+	for name, body := range storeFiles {
+		if err := os.WriteFile(filepath.Join(store, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
-	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
+	for name, body := range homeFiles {
+		if err := os.WriteFile(filepath.Join(home, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	return store, home
+}
+
+// Seam: CLIコマンド境界 (mdots push/pull/diff の代表例)
+// 実FS上の Store/dest を用い、run 経由の外部挙動のみを検証する。
+// Target 展開・フラグ解釈・差分詳細は CLI・設定・同期の各境界テストに寄せ、
+// ここでは配線の代表例だけを残す。
+func TestPushEndToEnd(t *testing.T) {
+	store, home := setupStoreWithHome(t,
+		map[string]string{"vimrc": "set number\n"},
+		nil,
+		"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+	)
 
 	if code := run([]string{"push"}, store); code != 0 {
 		t.Fatalf("run(push) exit = %d, want 0", code)
@@ -34,18 +53,40 @@ func TestPushEndToEnd(t *testing.T) {
 	}
 }
 
-func TestPushFromSubdirFails(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+// Target 配線の代表例。展開パターン自体は設定境界テストが保証する。
+func TestPushWithTargetRepresentative(t *testing.T) {
+	store, home := setupStoreWithHome(t,
+		map[string]string{
+			"common.conf": "common\n",
+			"win.conf":    "win\n",
+			"wsl.conf":    "wsl\n",
+		},
+		nil,
+		"entries:\n"+
+			"  - src: common.conf\n    dest: ~/.common.conf\n"+
+			"  - src: win.conf\n    dest: ~/.win.conf\n    target: win\n"+
+			"  - src: wsl.conf\n    dest: ~/.wsl.conf\n    target: wsl\n",
+	)
 
-	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("x\n"), 0o644); err != nil {
-		t.Fatal(err)
+	if code := run([]string{"push", "--target", "win"}, store); code != 0 {
+		t.Fatalf("run(push --target win) exit = %d, want 0", code)
 	}
-	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
+	for _, f := range []string{".common.conf", ".win.conf"} {
+		if _, err := os.Stat(filepath.Join(home, f)); err != nil {
+			t.Errorf("%s should be copied: %v", f, err)
+		}
 	}
+	if _, err := os.Stat(filepath.Join(home, ".wsl.conf")); err == nil {
+		t.Error(".wsl.conf should NOT be copied with --target win")
+	}
+}
+
+func TestPushFromSubdirFails(t *testing.T) {
+	store, home := setupStoreWithHome(t,
+		map[string]string{"vimrc": "x\n"},
+		nil,
+		"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+	)
 	sub := filepath.Join(store, "a", "b")
 	if err := os.MkdirAll(sub, 0o755); err != nil {
 		t.Fatal(err)
@@ -59,130 +100,12 @@ func TestPushFromSubdirFails(t *testing.T) {
 	}
 }
 
-func TestPushOnlyCommonEntries(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	if err := os.WriteFile(filepath.Join(store, "common.conf"), []byte("common\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(store, "win.conf"), []byte("win\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	yaml := "entries:\n" +
-		"  - src: common.conf\n    dest: ~/.common.conf\n" +
-		"  - src: win.conf\n    dest: ~/.win.conf\n    target: win\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if code := run([]string{"push"}, store); code != 0 {
-		t.Fatalf("run(push) exit = %d, want 0", code)
-	}
-	if _, err := os.Stat(filepath.Join(home, ".common.conf")); err != nil {
-		t.Errorf("common Entry should be copied: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(home, ".win.conf")); err == nil {
-		t.Error("win Entry should NOT be copied without --target")
-	}
-}
-
-func TestPushWithTarget(t *testing.T) {
-	setup := func(t *testing.T) (store, home string) {
-		t.Helper()
-		store = t.TempDir()
-		home = t.TempDir()
-		t.Setenv("HOME", home)
-
-		files := map[string]string{
-			"common.conf":  "common\n",
-			"explicit.conf": "explicit\n",
-			"win.conf":     "win\n",
-			"multi.conf":   "multi\n",
-			"wsl.conf":     "wsl\n",
-		}
-		for name, body := range files {
-			if err := os.WriteFile(filepath.Join(store, name), []byte(body), 0o644); err != nil {
-				t.Fatal(err)
-			}
-		}
-		yaml := "entries:\n" +
-			"  - src: common.conf\n    dest: ~/.common.conf\n" +
-			"  - src: explicit.conf\n    dest: ~/.explicit.conf\n    target: common\n" +
-			"  - src: win.conf\n    dest: ~/.win.conf\n    target: win\n" +
-			"  - src: multi.conf\n    dest: ~/.multi.conf\n    target: [win, wsl]\n" +
-			"  - src: wsl.conf\n    dest: ~/.wsl.conf\n    target: wsl\n"
-		if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		return store, home
-	}
-
-	tests := []struct {
-		name string
-		args []string
-		want []string
-		not  []string
-	}{
-		{"winはcommon+win", []string{"push", "--target", "win"}, []string{".common.conf", ".explicit.conf", ".win.conf", ".multi.conf"}, []string{".wsl.conf"}},
-		{"wslはcommon+wsl(配列一致含む)", []string{"push", "--target", "wsl"}, []string{".common.conf", ".explicit.conf", ".multi.conf", ".wsl.conf"}, []string{".win.conf"}},
-		{"未知Targetはcommonのみ", []string{"push", "--target", "linux"}, []string{".common.conf", ".explicit.conf"}, []string{".win.conf", ".multi.conf", ".wsl.conf"}},
-		{"target=形式も受付", []string{"push", "--target=win"}, []string{".common.conf", ".explicit.conf", ".win.conf", ".multi.conf"}, []string{".wsl.conf"}},
-		{"target commonはcommonのみと同等", []string{"push", "--target", "common"}, []string{".common.conf", ".explicit.conf"}, []string{".win.conf", ".multi.conf", ".wsl.conf"}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			store, home := setup(t)
-			if code := run(tt.args, store); code != 0 {
-				t.Fatalf("run(%v) exit = %d, want 0", tt.args, code)
-			}
-			for _, f := range tt.want {
-				if _, err := os.Stat(filepath.Join(home, f)); err != nil {
-					t.Errorf("%s should be copied: %v", f, err)
-				}
-			}
-			for _, f := range tt.not {
-				if _, err := os.Stat(filepath.Join(home, f)); err == nil {
-					t.Errorf("%s should NOT be copied with %v", f, tt.args)
-				}
-			}
-		})
-	}
-}
-
-func TestPushTargetFlagErrors(t *testing.T) {
-	store := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	for _, args := range [][]string{
-		{"push", "--target"},
-		{"push", "--target="},
-		{"push", "--unknown"},
-	} {
-		if code := run(args, store); code == 0 {
-			t.Errorf("run(%v): exit = 0, want non-zero", args)
-		}
-	}
-}
-
-// Seam: CLIコマンド境界 (mdots pull)
-// 実FS上の Store/dest を用い、end-to-end の外部挙動のみを検証する。
 func TestPullEndToEnd(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("edited\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	store, _ := setupStoreWithHome(t,
+		nil,
+		map[string]string{".vimrc": "edited\n"},
+		"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+	)
 
 	if code := run([]string{"pull"}, store); code != 0 {
 		t.Fatalf("run(pull) exit = %d, want 0", code)
@@ -196,245 +119,49 @@ func TestPullEndToEnd(t *testing.T) {
 	}
 }
 
-func TestPullWithTargetFiltersCommonPlusTarget(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	if err := os.WriteFile(filepath.Join(home, ".common.conf"), []byte("common edited\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".win.conf"), []byte("win edited\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".wsl.conf"), []byte("wsl edited\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	yaml := "entries:\n" +
-		"  - src: common.conf\n    dest: ~/.common.conf\n" +
-		"  - src: win.conf\n    dest: ~/.win.conf\n    target: win\n" +
-		"  - src: wsl.conf\n    dest: ~/.wsl.conf\n    target: wsl\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if code := run([]string{"pull", "--target", "win"}, store); code != 0 {
-		t.Fatalf("run(pull --target win) exit = %d, want 0", code)
-	}
-	if got, err := os.ReadFile(filepath.Join(store, "common.conf")); err != nil || string(got) != "common edited\n" {
-		t.Errorf("common should be pulled: content=%q err=%v", got, err)
-	}
-	if got, err := os.ReadFile(filepath.Join(store, "win.conf")); err != nil || string(got) != "win edited\n" {
-		t.Errorf("win should be pulled: content=%q err=%v", got, err)
-	}
-	if _, err := os.Stat(filepath.Join(store, "wsl.conf")); err == nil {
-		t.Error("wsl should NOT be pulled with --target win")
-	}
-}
-
+// 同期系エラーの exit 伝播の代表例。欠落・種別の網羅は同期境界テストが保証する。
 func TestPullMissingDestIsError(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	store, _ := setupStoreWithHome(t,
+		nil,
+		nil,
+		"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+	)
 
 	if code := run([]string{"pull"}, store); code == 0 {
 		t.Error("run(pull) with missing dest: exit = 0, want non-zero")
 	}
 }
 
-func TestPullDestDirIsError(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	if err := os.MkdirAll(filepath.Join(home, ".config"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	yaml := "entries:\n  - src: config\n    dest: ~/.config\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if code := run([]string{"pull"}, store); code == 0 {
-		t.Error("run(pull) with dir dest: exit = 0, want non-zero")
-	}
-}
-
-func TestPullWithoutStoreFails(t *testing.T) {
-	empty := t.TempDir()
-	if code := run([]string{"pull"}, empty); code == 0 {
-		t.Error("run(pull) without Store: exit = 0, want non-zero")
-	}
-}
-
-func TestPullTargetFlagErrors(t *testing.T) {
-	store := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	for _, args := range [][]string{
-		{"pull", "--target"},
-		{"pull", "--target="},
-		{"pull", "--unknown"},
-	} {
-		if code := run(args, store); code == 0 {
-			t.Errorf("run(%v): exit = 0, want non-zero", args)
+func TestDiffExitCodes(t *testing.T) {
+	t.Run("差分なしはexit 0", func(t *testing.T) {
+		store, _ := setupStoreWithHome(t,
+			map[string]string{"vimrc": "set number\n"},
+			map[string]string{".vimrc": "set number\n"},
+			"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+		)
+		if code := run([]string{"diff"}, store); code != 0 {
+			t.Errorf("run(diff) without changes: exit = %d, want 0", code)
 		}
-	}
+	})
+
+	t.Run("差分ありはexit非ゼロ", func(t *testing.T) {
+		store, _ := setupStoreWithHome(t,
+			map[string]string{"vimrc": "set number\n"},
+			map[string]string{".vimrc": "set nonumber\n"},
+			"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+		)
+		if code := run([]string{"diff"}, store); code == 0 {
+			t.Error("run(diff) with changes: exit = 0, want non-zero")
+		}
+	})
 }
 
-func TestPushWithoutStoreFails(t *testing.T) {
+// Store 未発見時の失敗は3コマンド共通。文言自体は設定境界テストが保証する。
+func TestCommandsWithoutStoreFail(t *testing.T) {
 	empty := t.TempDir()
-	if code := run([]string{"push"}, empty); code == 0 {
-		t.Error("run(push) without Store: exit = 0, want non-zero")
-	}
-}
-
-// Seam: CLIコマンド境界 (mdots diff)
-// 実FS上の Store/dest を用い、end-to-end の外部挙動のみを検証する。
-func TestDiffNoDiffExitsZero(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("set number\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("set number\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if code := run([]string{"diff"}, store); code != 0 {
-		t.Errorf("run(diff) without changes: exit = %d, want 0", code)
-	}
-	out, hasDiff, err := runDiff(store, "")
-	if err != nil {
-		t.Fatalf("runDiff error: %v", err)
-	}
-	if hasDiff {
-		t.Error("hasDiff = true, want false")
-	}
-	if out != "" {
-		t.Errorf("output = %q, want empty", out)
-	}
-}
-
-func TestDiffShowsDiffAndExitsNonZero(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	if err := os.WriteFile(filepath.Join(store, "vimrc"), []byte("set number\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".vimrc"), []byte("set nonumber\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	yaml := "entries:\n  - src: vimrc\n    dest: ~/.vimrc\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if code := run([]string{"diff"}, store); code == 0 {
-		t.Error("run(diff) with changes: exit = 0, want non-zero")
-	}
-	out, hasDiff, err := runDiff(store, "")
-	if err != nil {
-		t.Fatalf("runDiff error: %v", err)
-	}
-	if !hasDiff {
-		t.Fatal("hasDiff = false, want true")
-	}
-	if !strings.Contains(out, "---") || !strings.Contains(out, "+++") {
-		t.Errorf("output should contain ---/+++, got %q", out)
-	}
-}
-
-func TestDiffWithTargetFiltersCommonPlusTarget(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	// common は同一、win のみ差分あり、wsl は差分あっても対象外であるべき。
-	if err := os.WriteFile(filepath.Join(store, "common.conf"), []byte("common\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".common.conf"), []byte("common\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(store, "win.conf"), []byte("win old\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".win.conf"), []byte("win new\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(store, "wsl.conf"), []byte("wsl old\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".wsl.conf"), []byte("wsl new\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	yaml := "entries:\n" +
-		"  - src: common.conf\n    dest: ~/.common.conf\n" +
-		"  - src: win.conf\n    dest: ~/.win.conf\n    target: win\n" +
-		"  - src: wsl.conf\n    dest: ~/.wsl.conf\n    target: wsl\n"
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	out, hasDiff, err := runDiff(store, "win")
-	if err != nil {
-		t.Fatalf("runDiff error: %v", err)
-	}
-	if !hasDiff {
-		t.Fatal("hasDiff = false, want true (win differs)")
-	}
-	if !strings.Contains(out, "---") || !strings.Contains(out, "+++") {
-		t.Errorf("output should contain ---/+++, got %q", out)
-	}
-	if strings.Contains(out, "wsl.conf") {
-		t.Errorf("output should NOT contain wsl Entry with --target win, got %q", out)
-	}
-
-	// CLI フラグ経路も検証する: win 差分ありは exit 非ゼロ、対象外のみの差分は exit 0。
-	if code := run([]string{"diff", "--target", "win"}, store); code == 0 {
-		t.Error("run(diff --target win) with win changes: exit = 0, want non-zero")
-	}
-	if code := run([]string{"diff", "--target", "linux"}, store); code != 0 {
-		t.Errorf("run(diff --target linux) without applicable changes: exit = %d, want 0", code)
-	}
-}
-
-func TestDiffWithoutStoreFails(t *testing.T) {
-	empty := t.TempDir()
-	if code := run([]string{"diff"}, empty); code == 0 {
-		t.Error("run(diff) without Store: exit = 0, want non-zero")
-	}
-}
-
-func TestDiffTargetFlagErrors(t *testing.T) {
-	store := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	for _, args := range [][]string{
-		{"diff", "--target"},
-		{"diff", "--target="},
-		{"diff", "--unknown"},
-	} {
-		if code := run(args, store); code == 0 {
-			t.Errorf("run(%v): exit = 0, want non-zero", args)
+	for _, args := range [][]string{{"push"}, {"pull"}, {"diff"}} {
+		if code := run(args, empty); code == 0 {
+			t.Errorf("run(%v) without Store: exit = 0, want non-zero", args)
 		}
 	}
 }

--- a/sync/dryrun_test.go
+++ b/sync/dryrun_test.go
@@ -11,17 +11,13 @@ import (
 
 // Seam: sync パッケージ公開境界 (push/pull の dry-run)
 // 実FS上で書き込みなし・差分相当出力の外部挙動のみを検証する。
+// Store/dest 準備の定型は sync_test.go のヘルパに集約している。
 func TestDryRunPushShowsDiffWithoutWriting(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
-	if err := os.WriteFile(filepath.Join(store, "a"), []byte("new\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, filepath.Join(store, "a"), "new\n")
 	dest := filepath.Join(destRoot, "a")
-	if err := os.WriteFile(dest, []byte("old\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dest, "old\n")
 	entries := []config.Entry{{Src: "a", Dest: dest}}
 
 	out, hasDiff, err := DryRunPush(store, entries)
@@ -40,12 +36,9 @@ func TestDryRunPushShowsDiffWithoutWriting(t *testing.T) {
 }
 
 func TestDryRunPushReportsNewFileWithoutCreating(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
-	if err := os.WriteFile(filepath.Join(store, "a"), []byte("new\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, filepath.Join(store, "a"), "new\n")
 	dest := filepath.Join(destRoot, "a")
 	entries := []config.Entry{{Src: "a", Dest: dest}}
 
@@ -65,8 +58,7 @@ func TestDryRunPushReportsNewFileWithoutCreating(t *testing.T) {
 }
 
 func TestDryRunPushMissingSrcIsError(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 	entries := []config.Entry{{Src: "missing", Dest: filepath.Join(destRoot, "missing")}}
 	if _, _, err := DryRunPush(store, entries); err == nil {
 		t.Error("エラー expected, got nil")
@@ -74,17 +66,12 @@ func TestDryRunPushMissingSrcIsError(t *testing.T) {
 }
 
 func TestDryRunPullShowsDiffWithoutWriting(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
 	srcPath := filepath.Join(store, "a")
-	if err := os.WriteFile(srcPath, []byte("old\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, srcPath, "old\n")
 	dest := filepath.Join(destRoot, "a")
-	if err := os.WriteFile(dest, []byte("new\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dest, "new\n")
 	entries := []config.Entry{{Src: "a", Dest: dest}}
 
 	out, hasDiff, err := DryRunPull(store, entries)
@@ -103,13 +90,10 @@ func TestDryRunPullShowsDiffWithoutWriting(t *testing.T) {
 }
 
 func TestDryRunPullReportsNewStoreFileWithoutCreating(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
 	dest := filepath.Join(destRoot, "a")
-	if err := os.WriteFile(dest, []byte("new\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dest, "new\n")
 	entries := []config.Entry{{Src: "a", Dest: dest}}
 
 	out, hasDiff, err := DryRunPull(store, entries)
@@ -128,8 +112,7 @@ func TestDryRunPullReportsNewStoreFileWithoutCreating(t *testing.T) {
 }
 
 func TestDryRunPullMissingDestIsError(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 	entries := []config.Entry{{Src: "a", Dest: filepath.Join(destRoot, "missing")}}
 	if _, _, err := DryRunPull(store, entries); err == nil {
 		t.Error("エラー expected, got nil")

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -9,18 +9,35 @@ import (
 	"github.com/mogurastore/mdots/config"
 )
 
+// setupSyncDirs は Store/dest の実FS準備の定型を集約する。
+func setupSyncDirs(t *testing.T) (store, destRoot string) {
+	t.Helper()
+	return t.TempDir(), t.TempDir()
+}
+
+// writeTestFile はテスト用ファイル書き込みの定型を集約する。
+func writeTestFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// isolateHome は dest の ~ 展開先を隔離する定型を集約する。
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
 // Seam: sync パッケージ公開境界 (push)
 // Store/src → dest のファイルコピーを t.TempDir() の実FSで検証する。
 func TestPushCopiesStoreToDest(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	store, destRoot := setupSyncDirs(t)
 
-	srcPath := filepath.Join(store, "vimrc")
-	if err := os.WriteFile(srcPath, []byte("set number\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dest := filepath.Join(home, ".vimrc")
+	writeTestFile(t, filepath.Join(store, "vimrc"), "set number\n")
+	dest := filepath.Join(destRoot, ".vimrc")
 	entries := []config.Entry{{Src: "vimrc", Dest: dest}}
 
 	if err := Push(store, entries); err != nil {
@@ -36,13 +53,9 @@ func TestPushCopiesStoreToDest(t *testing.T) {
 }
 
 func TestPushCreatesParentDirs(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
-	srcPath := filepath.Join(store, "wezterm.lua")
-	if err := os.WriteFile(srcPath, []byte("return {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, filepath.Join(store, "wezterm.lua"), "return {}\n")
 	dest := filepath.Join(destRoot, ".config", "wezterm", "wezterm.lua")
 	entries := []config.Entry{{Src: "wezterm.lua", Dest: dest}}
 
@@ -55,14 +68,10 @@ func TestPushCreatesParentDirs(t *testing.T) {
 }
 
 func TestPushExpandsHomeDest(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	store, _ := setupSyncDirs(t)
+	home := isolateHome(t)
 
-	srcPath := filepath.Join(store, "bashrc")
-	if err := os.WriteFile(srcPath, []byte("export X=1\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, filepath.Join(store, "bashrc"), "export X=1\n")
 	entries := []config.Entry{{Src: "bashrc", Dest: "~/.bashrc"}}
 
 	if err := Push(store, entries); err != nil {
@@ -79,8 +88,7 @@ func TestPushExpandsHomeDest(t *testing.T) {
 
 func TestPushRejectsDirectories(t *testing.T) {
 	t.Run("srcがディレクトリはエラー", func(t *testing.T) {
-		store := t.TempDir()
-		destRoot := t.TempDir()
+		store, destRoot := setupSyncDirs(t)
 		if err := os.MkdirAll(filepath.Join(store, "mydir"), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -91,11 +99,8 @@ func TestPushRejectsDirectories(t *testing.T) {
 	})
 
 	t.Run("destがディレクトリはエラー", func(t *testing.T) {
-		store := t.TempDir()
-		destRoot := t.TempDir()
-		if err := os.WriteFile(filepath.Join(store, "a"), []byte("a"), 0o644); err != nil {
-			t.Fatal(err)
-		}
+		store, destRoot := setupSyncDirs(t)
+		writeTestFile(t, filepath.Join(store, "a"), "a")
 		destDir := filepath.Join(destRoot, "existing")
 		if err := os.MkdirAll(destDir, 0o755); err != nil {
 			t.Fatal(err)
@@ -108,16 +113,11 @@ func TestPushRejectsDirectories(t *testing.T) {
 }
 
 func TestPushOverwritesExisting(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
-	if err := os.WriteFile(filepath.Join(store, "a"), []byte("new"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, filepath.Join(store, "a"), "new")
 	dest := filepath.Join(destRoot, "a")
-	if err := os.WriteFile(dest, []byte("old"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dest, "old")
 	entries := []config.Entry{{Src: "a", Dest: dest}}
 
 	if err := Push(store, entries); err != nil {
@@ -133,11 +133,11 @@ func TestPushOverwritesExisting(t *testing.T) {
 }
 
 func TestPushPreservesPermission(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
 	srcPath := filepath.Join(store, "run.sh")
-	if err := os.WriteFile(srcPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+	writeTestFile(t, srcPath, "#!/bin/sh\n")
+	if err := os.Chmod(srcPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	dest := filepath.Join(destRoot, "run.sh")
@@ -158,14 +158,10 @@ func TestPushPreservesPermission(t *testing.T) {
 // Seam: sync パッケージ公開境界 (pull)
 // dest → Store/src のファイルコピーを t.TempDir() の実FSで検証する。
 func TestPullCopiesDestToStore(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	store, destRoot := setupSyncDirs(t)
 
-	dest := filepath.Join(home, ".vimrc")
-	if err := os.WriteFile(dest, []byte("edited\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	dest := filepath.Join(destRoot, ".vimrc")
+	writeTestFile(t, dest, "edited\n")
 	entries := []config.Entry{{Src: "vimrc", Dest: dest}}
 
 	if err := Pull(store, entries); err != nil {
@@ -181,16 +177,13 @@ func TestPullCopiesDestToStore(t *testing.T) {
 }
 
 func TestPullCreatesParentDirsOnStoreSide(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
 	dest := filepath.Join(destRoot, ".config", "wezterm", "wezterm.lua")
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(dest, []byte("return {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dest, "return {}\n")
 	entries := []config.Entry{{Src: filepath.Join(".config", "wezterm", "wezterm.lua"), Dest: dest}}
 
 	if err := Pull(store, entries); err != nil {
@@ -202,13 +195,10 @@ func TestPullCreatesParentDirsOnStoreSide(t *testing.T) {
 }
 
 func TestPullExpandsHomeDest(t *testing.T) {
-	store := t.TempDir()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	store, _ := setupSyncDirs(t)
+	home := isolateHome(t)
 
-	if err := os.WriteFile(filepath.Join(home, ".bashrc"), []byte("export X=1\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, filepath.Join(home, ".bashrc"), "export X=1\n")
 	entries := []config.Entry{{Src: "bashrc", Dest: "~/.bashrc"}}
 
 	if err := Pull(store, entries); err != nil {
@@ -225,8 +215,7 @@ func TestPullExpandsHomeDest(t *testing.T) {
 
 func TestPullRejectsDirectories(t *testing.T) {
 	t.Run("destがディレクトリはエラー", func(t *testing.T) {
-		store := t.TempDir()
-		destRoot := t.TempDir()
+		store, destRoot := setupSyncDirs(t)
 		destDir := filepath.Join(destRoot, "existing")
 		if err := os.MkdirAll(destDir, 0o755); err != nil {
 			t.Fatal(err)
@@ -238,12 +227,9 @@ func TestPullRejectsDirectories(t *testing.T) {
 	})
 
 	t.Run("Store側がディレクトリはエラー", func(t *testing.T) {
-		store := t.TempDir()
-		destRoot := t.TempDir()
+		store, destRoot := setupSyncDirs(t)
 		dest := filepath.Join(destRoot, "a")
-		if err := os.WriteFile(dest, []byte("a"), 0o644); err != nil {
-			t.Fatal(err)
-		}
+		writeTestFile(t, dest, "a")
 		if err := os.MkdirAll(filepath.Join(store, "a"), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -255,8 +241,7 @@ func TestPullRejectsDirectories(t *testing.T) {
 }
 
 func TestPullMissingDestIsError(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 	entries := []config.Entry{{Src: "missing", Dest: filepath.Join(destRoot, "missing")}}
 	if err := Pull(store, entries); err == nil {
 		t.Error("エラー expected, got nil")
@@ -264,17 +249,12 @@ func TestPullMissingDestIsError(t *testing.T) {
 }
 
 func TestPullOverwritesExisting(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
 	dest := filepath.Join(destRoot, "a")
-	if err := os.WriteFile(dest, []byte("new"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dest, "new")
 	srcPath := filepath.Join(store, "a")
-	if err := os.WriteFile(srcPath, []byte("old"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, srcPath, "old")
 	entries := []config.Entry{{Src: "a", Dest: dest}}
 
 	if err := Pull(store, entries); err != nil {
@@ -290,11 +270,11 @@ func TestPullOverwritesExisting(t *testing.T) {
 }
 
 func TestPullPreservesPermission(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
 	dest := filepath.Join(destRoot, "run.sh")
-	if err := os.WriteFile(dest, []byte("#!/bin/sh\n"), 0o755); err != nil {
+	writeTestFile(t, dest, "#!/bin/sh\n")
+	if err := os.Chmod(dest, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	entries := []config.Entry{{Src: "run.sh", Dest: dest}}
@@ -312,8 +292,7 @@ func TestPullPreservesPermission(t *testing.T) {
 }
 
 func TestPushMissingSrcIsError(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 	entries := []config.Entry{{Src: "missing", Dest: filepath.Join(destRoot, "missing")}}
 	if err := Push(store, entries); err == nil {
 		t.Error("エラー expected, got nil")
@@ -323,17 +302,12 @@ func TestPushMissingSrcIsError(t *testing.T) {
 // Seam: sync パッケージ公開境界 (diff)
 // Store/src と dest の差分を diff -u 風に出力する。実FSで検証する。
 func TestDiffNoDiffWhenIdentical(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
 	srcPath := filepath.Join(store, "vimrc")
-	if err := os.WriteFile(srcPath, []byte("set number\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, srcPath, "set number\n")
 	dest := filepath.Join(destRoot, ".vimrc")
-	if err := os.WriteFile(dest, []byte("set number\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dest, "set number\n")
 	entries := []config.Entry{{Src: "vimrc", Dest: dest}}
 
 	out, hasDiff, err := Diff(store, entries)
@@ -349,17 +323,12 @@ func TestDiffNoDiffWhenIdentical(t *testing.T) {
 }
 
 func TestDiffShowsUnifiedDiffWhenDifferent(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
 	srcPath := filepath.Join(store, "vimrc")
-	if err := os.WriteFile(srcPath, []byte("set number\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, srcPath, "set number\n")
 	dest := filepath.Join(destRoot, ".vimrc")
-	if err := os.WriteFile(dest, []byte("set nonumber\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dest, "set nonumber\n")
 	entries := []config.Entry{{Src: "vimrc", Dest: dest}}
 
 	out, hasDiff, err := Diff(store, entries)
@@ -376,12 +345,9 @@ func TestDiffShowsUnifiedDiffWhenDifferent(t *testing.T) {
 
 func TestDiffMissingFileIsError(t *testing.T) {
 	t.Run("src不在はエラー", func(t *testing.T) {
-		store := t.TempDir()
-		destRoot := t.TempDir()
+		store, destRoot := setupSyncDirs(t)
 		dest := filepath.Join(destRoot, "a")
-		if err := os.WriteFile(dest, []byte("a"), 0o644); err != nil {
-			t.Fatal(err)
-		}
+		writeTestFile(t, dest, "a")
 		entries := []config.Entry{{Src: "missing", Dest: dest}}
 		if _, _, err := Diff(store, entries); err == nil {
 			t.Error("エラー expected, got nil")
@@ -389,11 +355,8 @@ func TestDiffMissingFileIsError(t *testing.T) {
 	})
 
 	t.Run("dest不在はエラー", func(t *testing.T) {
-		store := t.TempDir()
-		destRoot := t.TempDir()
-		if err := os.WriteFile(filepath.Join(store, "a"), []byte("a"), 0o644); err != nil {
-			t.Fatal(err)
-		}
+		store, destRoot := setupSyncDirs(t)
+		writeTestFile(t, filepath.Join(store, "a"), "a")
 		entries := []config.Entry{{Src: "a", Dest: filepath.Join(destRoot, "missing")}}
 		if _, _, err := Diff(store, entries); err == nil {
 			t.Error("エラー expected, got nil")
@@ -402,21 +365,12 @@ func TestDiffMissingFileIsError(t *testing.T) {
 }
 
 func TestDiffMultipleEntriesOnlyDifferingOutput(t *testing.T) {
-	store := t.TempDir()
-	destRoot := t.TempDir()
+	store, destRoot := setupSyncDirs(t)
 
-	if err := os.WriteFile(filepath.Join(store, "same"), []byte("same\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(destRoot, "same"), []byte("same\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(store, "changed"), []byte("old\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(destRoot, "changed"), []byte("new\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, filepath.Join(store, "same"), "same\n")
+	writeTestFile(t, filepath.Join(destRoot, "same"), "same\n")
+	writeTestFile(t, filepath.Join(store, "changed"), "old\n")
+	writeTestFile(t, filepath.Join(destRoot, "changed"), "new\n")
 	entries := []config.Entry{
 		{Src: "same", Dest: filepath.Join(destRoot, "same")},
 		{Src: "changed", Dest: filepath.Join(destRoot, "changed")},


### PR DESCRIPTION
Closes #28

## 概要
保証を落とさずテスト重複だけ減らす。テストコードのみ変更、本番コードは無変更（+249/−699行）。

- main_test.go: setupStoreWithHome に集約、run経由e2eを代表例7件に縮小（Target配線・subdir失敗・文言・exitを保持）
- cli_test.go: help/version重複を削除しcliパッケージ境界に寄せる、dry-run統合を集約
- sync/sync_test.go・dryrun_test.go: 全項目保持のまま setupSyncDirs/writeTestFile/isolateHome に集約
- cli/cli_test.go・config/config_test.go: 無変更

## 検証
- go vet clean、全パッケージ green（PASS 74件）
- jj diffベースの2軸レビュー実施（Standards: hard違反なし、Spec: findingsなし）