### PR TITLE
feat: 設定ファイルをyamlからtomlに移行する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,7 +5,7 @@ dotfilesをファイルコピー（非symlink）で管理するCLI。Store（管
 ## Language
 
 **Store**:
-mdots.yaml を含む管理リポジトリのルート。カレント直下のmdots.yamlのみ参照する。
+mdots.toml を含む管理リポジトリのルート。カレント直下のmdots.tomlのみ参照する。
 _Avoid_: repo, dotfiles repo
 
 **Entry**:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mdots
 
 dotfilesをファイルコピー（非symlink）で管理するCLI。
-Store（`mdots.yaml` を含む管理リポジトリのルート）とホーム側を `push` / `pull` / `diff` で同期する。
+Store（`mdots.toml` を含む管理リポジトリのルート）とホーム側を `push` / `pull` / `diff` で同期する。
 
 ## 導入
 
@@ -21,21 +21,25 @@ mise use ubi:mogurastore/mdots@latest
 
 ## 最小サンプル
 
-Store（管理リポジトリ）の直下に `mdots.yaml` を置く。
+Store（管理リポジトリ）の直下に `mdots.toml` を置く。
 `src` は Store 相対のファイルパス、`dest` は `~` 展開される配置先パス、
 `target` は省略時 common 扱いの自由文字列（例: `win`, `wsl`）。
 
-```yaml
-# <Store>/mdots.yaml
-entries:
-  - src: vimrc
-    dest: ~/.vimrc
-  - src: wezterm.lua
-    dest: ~/.config/wezterm/wezterm.lua
-    target: win
-  - src: shared.conf
-    dest: ~/.config/shared.conf
-    target: [win, wsl]
+```toml
+# <Store>/mdots.toml
+[[entries]]
+src = "vimrc"
+dest = "~/.vimrc"
+
+[[entries]]
+src = "wezterm.lua"
+dest = "~/.config/wezterm/wezterm.lua"
+target = "win"
+
+[[entries]]
+src = "shared.conf"
+dest = "~/.config/shared.conf"
+target = ["win", "wsl"]
 ```
 
 ```sh
@@ -64,5 +68,5 @@ mdots --version         # バージョンを表示する（ldflags -X main.versi
 
 - `--target` 未指定時は common のみ、指定時は common + 指定 Target が対象になる。
 - `--dry-run` は実際に書き込まず差分相当を出力する。差分ありは exit 1、差分なしは exit 0。
-- `mdots.yaml` が見つからないときは `mdots.yaml not found in <cwd>` と表示し exit 1 になる。
-- Store はカレント直下の `mdots.yaml` のみ参照する。Store直下で実行し、サブディレクトリからは実行できない。
+- `mdots.toml` が見つからないときは `mdots.toml not found in <cwd>` と表示し exit 1 になる。
+- Store はカレント直下の `mdots.toml` のみ参照する。Store直下で実行し、サブディレクトリからは実行できない。

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -22,7 +22,7 @@ import (
 const GlobalHelp = `usage: mdots <push|pull|diff> [options]
 
 dotfilesをファイルコピー（非symlink）で管理するCLI。
-Store（mdots.yaml を含む管理リポジトリのルート）の直下で実行する。mdots.yaml はカレント直下のみ参照する。
+Store（mdots.toml を含む管理リポジトリのルート）の直下で実行する。mdots.toml はカレント直下のみ参照する。
 
 commands:
   push  Storeからdestへファイルをコピーする

--- a/cli_test.go
+++ b/cli_test.go
@@ -18,7 +18,7 @@ func TestDryRunIntegration(t *testing.T) {
 		store, home := setupStoreWithHome(t,
 			map[string]string{"vimrc": "new\n"},
 			map[string]string{".vimrc": "old\n"},
-			"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+			"[[entries]]\nsrc = \"vimrc\"\ndest = \"~/.vimrc\"\n",
 		)
 
 		var out, errOut bytes.Buffer
@@ -37,7 +37,7 @@ func TestDryRunIntegration(t *testing.T) {
 		store, _ := setupStoreWithHome(t,
 			map[string]string{"vimrc": "old\n"},
 			map[string]string{".vimrc": "new\n"},
-			"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+			"[[entries]]\nsrc = \"vimrc\"\ndest = \"~/.vimrc\"\n",
 		)
 
 		var out, errOut bytes.Buffer
@@ -56,7 +56,7 @@ func TestDryRunIntegration(t *testing.T) {
 		store, _ := setupStoreWithHome(t,
 			map[string]string{"vimrc": "same\n"},
 			map[string]string{".vimrc": "same\n"},
-			"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+			"[[entries]]\nsrc = \"vimrc\"\ndest = \"~/.vimrc\"\n",
 		)
 
 		var out, errOut bytes.Buffer
@@ -67,7 +67,7 @@ func TestDryRunIntegration(t *testing.T) {
 }
 
 func TestDiffRejectsDryRun(t *testing.T) {
-	store, _ := setupStoreWithHome(t, nil, nil, "entries: []\n")
+	store, _ := setupStoreWithHome(t, nil, nil, "")
 	var out, errOut bytes.Buffer
 	if code := runWithWriters([]string{"diff", "--dry-run"}, store, &out, &errOut); code == 0 {
 		t.Error("run(diff --dry-run): exit = 0, want non-zero")
@@ -80,7 +80,7 @@ func TestStoreNotFoundFriendlyError(t *testing.T) {
 	if code := runWithWriters([]string{"push"}, empty, &out, &errOut); code == 0 {
 		t.Fatal("run(push) without Store: exit = 0, want non-zero")
 	}
-	if !strings.Contains(errOut.String(), "mdots.yaml not found in "+empty) {
+	if !strings.Contains(errOut.String(), "mdots.toml not found in "+empty) {
 		t.Errorf("stderr should contain friendly message, got %q", errOut.String())
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,45 +6,48 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/BurntSushi/toml"
 )
 
-// Config は Store 直下の mdots.yaml 全体を表す。
+// Config は Store 直下の mdots.toml 全体を表す。
 type Config struct {
-	Entries []Entry `yaml:"entries"`
+	Entries []Entry `toml:"entries"`
 }
 
 // Entry は1つの管理対象を表す src/dest ペア。
 // src は Store 相対のファイルパス、dest は ~ 展開される配置先パス。
 // Target は適用先を識別する自由文字列。省略時は common として扱う。
 type Entry struct {
-	Src    string     `yaml:"src"`
-	Dest   string     `yaml:"dest"`
-	Target TargetList `yaml:"target,omitempty"`
+	Src    string     `toml:"src"`
+	Dest   string     `toml:"dest"`
+	Target TargetList `toml:"target,omitempty"`
 }
 
 // TargetList は string | string[] を受け付ける Target の集合。
 type TargetList []string
 
-// UnmarshalYAML は string | string[] の両方を受け付ける。
-func (t *TargetList) UnmarshalYAML(value *yaml.Node) error {
-	switch value.Tag {
-	case "!!str":
-		var single string
-		if err := value.Decode(&single); err != nil {
-			return err
-		}
-		*t = TargetList{single}
-		return nil
-	case "!!seq":
-		var multi []string
-		if err := value.Decode(&multi); err != nil {
-			return fmt.Errorf("target must be string or string[]")
-		}
-		*t = TargetList(multi)
-		return nil
-	case "!!null":
+// UnmarshalTOML は string | string[] の両方を受け付ける。
+func (t *TargetList) UnmarshalTOML(value interface{}) error {
+	switch v := value.(type) {
+	case nil:
 		*t = nil
+		return nil
+	case string:
+		*t = TargetList{v}
+		return nil
+	case []interface{}:
+		out := make(TargetList, 0, len(v))
+		for _, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return fmt.Errorf("target must be string or string[]")
+			}
+			out = append(out, s)
+		}
+		*t = out
+		return nil
+	case []string:
+		*t = TargetList(v)
 		return nil
 	default:
 		return fmt.Errorf("target must be string or string[]")
@@ -93,14 +96,14 @@ func FilterByTarget(entries []Entry, target string) []Entry {
 	return out
 }
 
-// Load は Store の mdots.yaml を読み込み、validation して返す。
+// Load は Store の mdots.toml を読み込み、validation して返す。
 func Load(path string) (Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return Config{}, err
 	}
 	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := toml.Unmarshal(data, &cfg); err != nil {
 		return Config{}, err
 	}
 	if err := cfg.Validate(); err != nil {
@@ -147,15 +150,15 @@ func (e Entry) ExpandedDest() (string, error) {
 	return ExpandDest(e.Dest)
 }
 
-// FindStore はカレント直下の mdots.yaml のみを参照し、
+// FindStore はカレント直下の mdots.toml のみを参照し、
 // 見つかった Store ルートを返す。見つからないときは in <cwd> 形式のエラーを返す。
 func FindStore(startDir string) (string, error) {
 	abs, err := filepath.Abs(startDir)
 	if err != nil {
 		return "", err
 	}
-	if _, err := os.Stat(filepath.Join(abs, "mdots.yaml")); err == nil {
+	if _, err := os.Stat(filepath.Join(abs, "mdots.toml")); err == nil {
 		return abs, nil
 	}
-	return "", fmt.Errorf("mdots.yaml not found in %s", abs)
+	return "", fmt.Errorf("mdots.toml not found in %s", abs)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -45,17 +45,30 @@ func TestFilterByTarget(t *testing.T) {
 	}
 }
 
-// Seam: config パッケージ公開境界 (Store の mdots.yaml 読込・validation)
+// Seam: config パッケージ公開境界 (Store の mdots.toml 読込・validation)
 // Entry の src/dest 必須と target の string | string[] を外部挙動で検証する。
 func TestLoadStoreConfig(t *testing.T) {
 	t.Run("stringと配列のTargetを読み込める", func(t *testing.T) {
 		dir := t.TempDir()
-		p := filepath.Join(dir, "mdots.yaml")
-		body := "entries:\n" +
-			"  - src: vimrc\n    dest: ~/.vimrc\n" +
-			"  - src: wezterm.lua\n    dest: ~/.config/wezterm/wezterm.lua\n    target: win\n" +
-			"  - src: shared.conf\n    dest: ~/.config/shared.conf\n    target: [win, wsl]\n" +
-			"  - src: common.conf\n    dest: ~/.config/common.conf\n    target: common\n"
+		p := filepath.Join(dir, "mdots.toml")
+		body := "[[entries]]\n" +
+			"src = \"vimrc\"\n" +
+			"dest = \"~/.vimrc\"\n" +
+			"\n" +
+			"[[entries]]\n" +
+			"src = \"wezterm.lua\"\n" +
+			"dest = \"~/.config/wezterm/wezterm.lua\"\n" +
+			"target = \"win\"\n" +
+			"\n" +
+			"[[entries]]\n" +
+			"src = \"shared.conf\"\n" +
+			"dest = \"~/.config/shared.conf\"\n" +
+			"target = [\"win\", \"wsl\"]\n" +
+			"\n" +
+			"[[entries]]\n" +
+			"src = \"common.conf\"\n" +
+			"dest = \"~/.config/common.conf\"\n" +
+			"target = \"common\"\n"
 		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -77,12 +90,12 @@ func TestLoadStoreConfig(t *testing.T) {
 	t.Run("src/dest必須のvalidation", func(t *testing.T) {
 		dir := t.TempDir()
 		cases := map[string]string{
-			"src欠落":     "entries:\n  - dest: ~/.a\n",
-			"dest欠落":    "entries:\n  - src: a\n",
-			"target型不正": "entries:\n  - src: a\n    dest: ~/.a\n    target: 123\n",
+			"src欠落":     "[[entries]]\ndest = \"~/.a\"\n",
+			"dest欠落":    "[[entries]]\nsrc = \"a\"\n",
+			"target型不正": "[[entries]]\nsrc = \"a\"\ndest = \"~/.a\"\ntarget = 123\n",
 		}
 		for name, body := range cases {
-			p := filepath.Join(dir, "mdots.yaml")
+			p := filepath.Join(dir, "mdots.toml")
 			if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
 				t.Fatal(err)
 			}
@@ -112,11 +125,11 @@ func TestExpandDest(t *testing.T) {
 }
 
 // Seam: config パッケージ公開境界 (Store 発見)
-// カレント直下の mdots.yaml のみを参照する外部挙動を t.TempDir() の実FSで検証する。
+// カレント直下の mdots.toml のみを参照する外部挙動を t.TempDir() の実FSで検証する。
 func TestFindStore(t *testing.T) {
 	t.Run("カレント直下のStoreを発見できる", func(t *testing.T) {
 		root := t.TempDir()
-		if err := os.WriteFile(filepath.Join(root, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(root, "mdots.toml"), []byte(""), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		got, err := FindStore(root)
@@ -130,7 +143,7 @@ func TestFindStore(t *testing.T) {
 
 	t.Run("サブディレクトリからは失敗しin形式のエラー", func(t *testing.T) {
 		root := t.TempDir()
-		if err := os.WriteFile(filepath.Join(root, "mdots.yaml"), []byte("entries: []\n"), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(root, "mdots.toml"), []byte(""), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		sub := filepath.Join(root, "a", "b")
@@ -141,8 +154,8 @@ func TestFindStore(t *testing.T) {
 		if err == nil {
 			t.Fatal("エラー expected, got nil")
 		}
-		if !strings.Contains(err.Error(), "mdots.yaml not found in "+sub) {
-			t.Errorf("エラーメッセージ不正: got %q, want contain %q", err.Error(), "mdots.yaml not found in "+sub)
+		if !strings.Contains(err.Error(), "mdots.toml not found in "+sub) {
+			t.Errorf("エラーメッセージ不正: got %q, want contain %q", err.Error(), "mdots.toml not found in "+sub)
 		}
 	})
 
@@ -152,8 +165,8 @@ func TestFindStore(t *testing.T) {
 		if err == nil {
 			t.Fatal("エラー expected, got nil")
 		}
-		if !strings.Contains(err.Error(), "mdots.yaml not found in "+start) {
-			t.Errorf("エラーメッセージ不正: got %q, want contain %q", err.Error(), "mdots.yaml not found in "+start)
+		if !strings.Contains(err.Error(), "mdots.toml not found in "+start) {
+			t.Errorf("エラーメッセージ不正: got %q, want contain %q", err.Error(), "mdots.toml not found in "+start)
 		}
 		if strings.Contains(err.Error(), "searched from") {
 			t.Errorf("旧文言が残っている: got %q", err.Error())

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/mogurastore/mdots
 go 1.27.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/urfave/cli/v3 v3.11.0
-	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -6,7 +8,5 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli/v3 v3.11.0 h1:P/euJp99kb9p0tlVY+iYTLYYTAQlfl0hR2gUO1Img1Q=
 github.com/urfave/cli/v3 v3.11.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func resolveEntries(cwd string, target string) (string, []config.Entry, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	cfg, err := config.Load(filepath.Join(store, "mdots.yaml"))
+	cfg, err := config.Load(filepath.Join(store, "mdots.toml"))
 	if err != nil {
 		return "", nil, err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -8,8 +8,8 @@ import (
 
 // setupStoreWithHome は Store 準備・HOME 隔離の定型を集約する。
 // storeFiles は Store 直下に作るファイル群、homeFiles は HOME 直下に作る
-// ファイル群、yaml は mdots.yaml の本文。HOME は t.Setenv で隔離する。
-func setupStoreWithHome(t *testing.T, storeFiles, homeFiles map[string]string, yaml string) (store, home string) {
+// ファイル群、tomlBody は mdots.toml の本文。HOME は t.Setenv で隔離する。
+func setupStoreWithHome(t *testing.T, storeFiles, homeFiles map[string]string, tomlBody string) (store, home string) {
 	t.Helper()
 	store = t.TempDir()
 	home = t.TempDir()
@@ -24,7 +24,7 @@ func setupStoreWithHome(t *testing.T, storeFiles, homeFiles map[string]string, y
 			t.Fatal(err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(store, "mdots.yaml"), []byte(yaml), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(store, "mdots.toml"), []byte(tomlBody), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	return store, home
@@ -38,7 +38,7 @@ func TestPushEndToEnd(t *testing.T) {
 	store, home := setupStoreWithHome(t,
 		map[string]string{"vimrc": "set number\n"},
 		nil,
-		"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+		"[[entries]]\nsrc = \"vimrc\"\ndest = \"~/.vimrc\"\n",
 	)
 
 	if code := run([]string{"push"}, store); code != 0 {
@@ -62,10 +62,9 @@ func TestPushWithTargetRepresentative(t *testing.T) {
 			"wsl.conf":    "wsl\n",
 		},
 		nil,
-		"entries:\n"+
-			"  - src: common.conf\n    dest: ~/.common.conf\n"+
-			"  - src: win.conf\n    dest: ~/.win.conf\n    target: win\n"+
-			"  - src: wsl.conf\n    dest: ~/.wsl.conf\n    target: wsl\n",
+		"[[entries]]\nsrc = \"common.conf\"\ndest = \"~/.common.conf\"\n"+
+			"[[entries]]\nsrc = \"win.conf\"\ndest = \"~/.win.conf\"\ntarget = \"win\"\n"+
+			"[[entries]]\nsrc = \"wsl.conf\"\ndest = \"~/.wsl.conf\"\ntarget = \"wsl\"\n",
 	)
 
 	if code := run([]string{"push", "--target", "win"}, store); code != 0 {
@@ -85,7 +84,7 @@ func TestPushFromSubdirFails(t *testing.T) {
 	store, home := setupStoreWithHome(t,
 		map[string]string{"vimrc": "x\n"},
 		nil,
-		"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+		"[[entries]]\nsrc = \"vimrc\"\ndest = \"~/.vimrc\"\n",
 	)
 	sub := filepath.Join(store, "a", "b")
 	if err := os.MkdirAll(sub, 0o755); err != nil {
@@ -104,7 +103,7 @@ func TestPullEndToEnd(t *testing.T) {
 	store, _ := setupStoreWithHome(t,
 		nil,
 		map[string]string{".vimrc": "edited\n"},
-		"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+		"[[entries]]\nsrc = \"vimrc\"\ndest = \"~/.vimrc\"\n",
 	)
 
 	if code := run([]string{"pull"}, store); code != 0 {
@@ -124,7 +123,7 @@ func TestPullMissingDestIsError(t *testing.T) {
 	store, _ := setupStoreWithHome(t,
 		nil,
 		nil,
-		"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+		"[[entries]]\nsrc = \"vimrc\"\ndest = \"~/.vimrc\"\n",
 	)
 
 	if code := run([]string{"pull"}, store); code == 0 {
@@ -137,7 +136,7 @@ func TestDiffExitCodes(t *testing.T) {
 		store, _ := setupStoreWithHome(t,
 			map[string]string{"vimrc": "set number\n"},
 			map[string]string{".vimrc": "set number\n"},
-			"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+			"[[entries]]\nsrc = \"vimrc\"\ndest = \"~/.vimrc\"\n",
 		)
 		if code := run([]string{"diff"}, store); code != 0 {
 			t.Errorf("run(diff) without changes: exit = %d, want 0", code)
@@ -148,7 +147,7 @@ func TestDiffExitCodes(t *testing.T) {
 		store, _ := setupStoreWithHome(t,
 			map[string]string{"vimrc": "set number\n"},
 			map[string]string{".vimrc": "set nonumber\n"},
-			"entries:\n  - src: vimrc\n    dest: ~/.vimrc\n",
+			"[[entries]]\nsrc = \"vimrc\"\ndest = \"~/.vimrc\"\n",
 		)
 		if code := run([]string{"diff"}, store); code == 0 {
 			t.Error("run(diff) with changes: exit = 0, want non-zero")


### PR DESCRIPTION
mdots.yamlからmdots.tomlに完全移行する。

- config: BurntSushi/toml v1.6.0に切替え、string|string[]のtargetを維持、[[entries]]形式
- Store発見・読込・エラー文をmdots.tomlに統一
- テスト・README・CONTEXT・help文を更新、yaml依存を削除
- 検証: go test ./...、go vet ./... クリーン