### PR TITLE
feat: initコマンドを追加する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,3 +31,7 @@ _Avoid_: capture, import
 **diff**:
 Storeとdestの差分を表示する操作。
 _Avoid_: status, check
+
+**init**:
+Storeにmdots.toml雛形を作る操作。
+_Avoid_: create, new, setup

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ mise use ubi:mogurastore/mdots@latest
 ## 最小サンプル
 
 Store（管理リポジトリ）の直下に `mdots.toml` を置く。
+`mdots init` でコメント付き雛形を作れる。
 `src` は Store 相対のファイルパス、`dest` は `~` 展開される配置先パス、
 `target` は省略時 common 扱いの自由文字列（例: `win`, `wsl`）。
 
@@ -65,8 +66,10 @@ mdots --version         # バージョンを表示する（ldflags -X main.versi
 | `push [--target <name>] [--dry-run]` | Store から dest へコピーする |
 | `pull [--target <name>] [--dry-run]` | dest から Store へ回収する |
 | `diff [--target <name>]` | Store と dest の差分を表示する |
+| `init` | カレント直下に `mdots.toml` 雛形を作る |
 
 - `--target` 未指定時は common のみ、指定時は common + 指定 Target が対象になる。
 - `--dry-run` は実際に書き込まず差分相当を出力する。差分ありは exit 1、差分なしは exit 0。
 - `mdots.toml` が見つからないときは `mdots.toml not found in <cwd>` と表示し exit 1 になる。
+- `init` は雛形を作る。既にあるときは `mdots.toml already exists in <cwd>` と表示し exit 1 になる。
 - Store はカレント直下の `mdots.toml` のみ参照する。Store直下で実行し、サブディレクトリからは実行できない。

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -19,7 +19,7 @@ import (
 	cliv3 "github.com/urfave/cli/v3"
 )
 
-const GlobalHelp = `usage: mdots <push|pull|diff> [options]
+const GlobalHelp = `usage: mdots <push|pull|diff|init> [options]
 
 dotfilesをファイルコピー（非symlink）で管理するCLI。
 Store（mdots.toml を含む管理リポジトリのルート）の直下で実行する。mdots.toml はカレント直下のみ参照する。
@@ -28,6 +28,7 @@ commands:
   push  Storeからdestへファイルをコピーする
   pull  destからStoreへファイルを回収する
   diff  Storeとdestの差分を表示する
+  init  Storeにmdots.toml雛形を作る
 
 global options:
   -h, --help     使い方を表示する
@@ -69,7 +70,17 @@ options:
   -h, --help       使い方を表示する
 `
 
-// Executor は push/pull/diff の内部実行系への委譲口である。
+const InitHelp = `usage: mdots init
+
+Storeにmdots.toml雛形を作る。
+カレント直下に雛形を作り、見て使い方が分かるコメントとサンプルを含む。
+既にあるときは mdots.toml already exists in <cwd> と表示し exit 1 になる。
+
+options:
+  -h, --help       使い方を表示する
+`
+
+// Executor は push/pull/diff/init の内部実行系への委譲口である。
 // 表面（文面・exit）は本パッケージが保ち、副作用のある処理だけを委譲する。
 type Executor interface {
 	Push(cwd, target string) error
@@ -77,6 +88,7 @@ type Executor interface {
 	Diff(cwd, target string) (out string, hasDiff bool, err error)
 	PushDryRun(cwd, target string, stdout, stderr io.Writer) int
 	PullDryRun(cwd, target string, stdout, stderr io.Writer) int
+	Init(cwd string) error
 }
 
 // exitError は Action が呼び出し元 Run へ exit code を伝えるための内用エラーで、
@@ -116,7 +128,7 @@ func Run(args []string, cwd, version string, ex Executor, stdout, stderr io.Writ
 	case "--version", "-V", "version":
 		fmt.Fprintf(stdout, "mdots %s\n", version)
 		return 0
-	case "push", "pull", "diff":
+	case "push", "pull", "diff", "init":
 		// 宣言ツリーへ進む。
 	default:
 		fmt.Fprintf(stderr, "unknown command: %s\n", args[0])
@@ -203,6 +215,13 @@ func (r *runner) newCommand() *cliv3.Command {
 				},
 				OnUsageError: r.usageError(DiffHelp),
 				Action:       r.diffAction,
+			},
+			{
+				Name:               "init",
+				Usage:              "Storeにmdots.toml雛形を作る",
+				CustomHelpTemplate: InitHelp,
+				OnUsageError:       r.usageError(InitHelp),
+				Action:             r.initAction,
 			},
 			{
 				// version サブコマンドの宣言。従来の先頭トークン優先を保つため
@@ -350,5 +369,17 @@ func (r *runner) diffAction(_ context.Context, cmd *cliv3.Command) error {
 		fmt.Fprint(r.stdout, out)
 		return &exitError{code: 1}
 	}
+	return nil
+}
+
+func (r *runner) initAction(_ context.Context, cmd *cliv3.Command) error {
+	if cmd.Args().Present() {
+		return r.argError(InitHelp, cmd.Args().First())
+	}
+	if err := r.exec.Init(r.cwd); err != nil {
+		fmt.Fprintln(r.stderr, err)
+		return &exitError{code: 1}
+	}
+	fmt.Fprintln(r.stdout, "created mdots.toml")
 	return nil
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -32,6 +32,9 @@ type fakeExecutor struct {
 	pullDryCode  int
 	pullDryOut   string
 	pullDryCalls int
+
+	initCalls int
+	initErr   error
 }
 
 func (f *fakeExecutor) Push(cwd, target string) error {
@@ -63,6 +66,11 @@ func (f *fakeExecutor) PullDryRun(cwd, target string, stdout, stderr io.Writer) 
 	f.pullTarget = target
 	io.WriteString(stdout, f.pullDryOut)
 	return f.pullDryCode
+}
+
+func (f *fakeExecutor) Init(cwd string) error {
+	f.initCalls++
+	return f.initErr
 }
 
 func runCli(t *testing.T, ex Executor, args []string) (int, string, string) {
@@ -260,5 +268,62 @@ func TestCliExecutorErrorExitsNonZero(t *testing.T) {
 	}
 	if !strings.Contains(errOut, "boom") {
 		t.Errorf("stderr should contain executor error, got %q", errOut)
+	}
+}
+
+// Seam: CLIコマンド境界 (init 雛形作成)
+// 成功・help・余分引数・実行エラーの外部挙動のみを検証する。
+func TestCliInitDispatches(t *testing.T) {
+	ex := &fakeExecutor{}
+	code, out, _ := runCli(t, ex, []string{"init"})
+	if code != 0 {
+		t.Fatalf("Run(init) exit = %d, want 0", code)
+	}
+	if ex.initCalls != 1 {
+		t.Fatalf("Init calls = %d, want 1", ex.initCalls)
+	}
+	for _, want := range []string{"created", "mdots.toml"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output should contain %q, got %q", want, out)
+		}
+	}
+}
+
+func TestCliInitHelp(t *testing.T) {
+	for _, args := range [][]string{{"init", "--help"}, {"init", "-h"}} {
+		ex := &fakeExecutor{}
+		code, out, _ := runCli(t, ex, args)
+		if code != 0 {
+			t.Fatalf("Run(%v) exit = %d, want 0", args, code)
+		}
+		for _, want := range []string{"init", "mdots.toml"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("Run(%v): output should contain %q, got %q", args, want, out)
+			}
+		}
+		if ex.initCalls != 0 {
+			t.Errorf("Run(%v): Init must not run on --help", args)
+		}
+	}
+}
+
+func TestCliInitRejectsExtraArgs(t *testing.T) {
+	ex := &fakeExecutor{}
+	if code, _, _ := runCli(t, ex, []string{"init", "extra"}); code == 0 {
+		t.Error("Run(init extra): exit = 0, want non-zero")
+	}
+	if ex.initCalls != 0 {
+		t.Error("Init must not run with extra args")
+	}
+}
+
+func TestCliInitExecutorError(t *testing.T) {
+	ex := &fakeExecutor{initErr: errors.New("mdots.toml already exists in /tmp/x")}
+	code, _, errOut := runCli(t, ex, []string{"init"})
+	if code == 0 {
+		t.Fatal("Run(init) with executor error: exit = 0, want non-zero")
+	}
+	if !strings.Contains(errOut, "mdots.toml already exists") {
+		t.Errorf("stderr should contain already exists, got %q", errOut)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -150,6 +150,63 @@ func (e Entry) ExpandedDest() (string, error) {
 	return ExpandDest(e.Dest)
 }
 
+// Template は init が作る mdots.toml 雛形である。
+// 見て使い方を理解できるよう日本語コメントで push/pull/diff と
+// src/dest/target を説明し、サンプル Entry はすべてコメントアウト済み。
+// 生成物は Load/Validate を通る（Entry ゼロ件）。
+const Template = `# mdots.toml — Store（このファイルがあるディレクトリ）直下で mdots を実行する。
+# Store はカレント直下の mdots.toml のみ参照する。サブディレクトリからは実行できない。
+#
+# 使い方:
+#   mdots push              # common のみを Store から dest へコピー
+#   mdots push --target win # common + win を対象にする
+#   mdots pull --target win # dest から Store へ回収する
+#   mdots diff              # 差分を diff -u 風に確認する（差分なし: exit 0、差分あり: exit 1）
+#
+# Entry（1つの管理対象）:
+#   src    = Store相対のファイルパス
+#   dest   = 配置先パス（~ / ~/... はホームに展開）
+#   target = 省略時 common。--target 未指定時は common のみ、指定時は common + 指定Target が対象
+#
+# コメントを外して使う。まず common の1件から始めるのがおすすめ。
+#
+# [[entries]]
+# src = "vimrc"
+# dest = "~/.vimrc"
+#
+# [[entries]]
+# src = "wezterm.lua"
+# dest = "~/.config/wezterm/wezterm.lua"
+# target = "win"
+#
+# [[entries]]
+# src = "shared.conf"
+# dest = "~/.config/shared.conf"
+# target = ["win", "wsl"]
+`
+
+// Init は指定ディレクトリ直下に mdots.toml 雛形を作り、作ったパスを返す。
+// 既にあるときは mdots.toml already exists in <dir> 形式のエラーを返す。
+func Init(dir string) (string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(abs, "mdots.toml")
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return "", fmt.Errorf("mdots.toml already exists in %s", abs)
+		}
+		return "", err
+	}
+	defer f.Close()
+	if _, err := f.WriteString(Template); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
 // FindStore はカレント直下の mdots.toml のみを参照し、
 // 見つかった Store ルートを返す。見つからないときは in <cwd> 形式のエラーを返す。
 func FindStore(startDir string) (string, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -124,6 +124,34 @@ func TestExpandDest(t *testing.T) {
 	}
 }
 
+// Seam: config パッケージ公開境界 (init 雛形作成)
+// 空Store作成・既存ありエラー・生成物がLoadを通る外部挙動を検証する。
+func TestInitCreatesTemplate(t *testing.T) {
+	dir := t.TempDir()
+	p, err := Init(dir)
+	if err != nil {
+		t.Fatalf("Init error: %v", err)
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{"mdots push", "src =", "dest =", "target", "common", "[[entries]]"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("template should contain %q, got:\n%s", want, body)
+		}
+	}
+	if _, err := Load(p); err != nil {
+		t.Errorf("generated template must Load: %v", err)
+	}
+	if _, err := Init(dir); err == nil {
+		t.Fatal("second Init: エラー expected, got nil")
+	} else if !strings.Contains(err.Error(), "mdots.toml already exists in ") {
+		t.Errorf("既存ありエラーメッセージ不正: got %q", err.Error())
+	}
+}
+
 // Seam: config パッケージ公開境界 (Store 発見)
 // カレント直下の mdots.toml のみを参照する外部挙動を t.TempDir() の実FSで検証する。
 func TestFindStore(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -44,6 +44,8 @@ func (cliExecutor) Pull(cwd, target string) error { return runPull(cwd, target) 
 
 func (cliExecutor) Diff(cwd, target string) (string, bool, error) { return runDiff(cwd, target) }
 
+func (cliExecutor) Init(cwd string) error { return runInit(cwd) }
+
 func (cliExecutor) PushDryRun(cwd, target string, stdout, stderr io.Writer) int {
 	return runPushDryRun(cwd, target, stdout, stderr)
 }
@@ -80,6 +82,13 @@ func runCopy(cwd string, target string, copyFn func(string, []config.Entry) erro
 // target 未指定時は common のみが対象になる。
 func runPush(cwd string, target string) error {
 	return runCopy(cwd, target, sync.Push)
+}
+
+// runInit はカレント直下に mdots.toml 雛形を作る。
+// 既にあるときは config.Init が already exists エラーを返す。
+func runInit(cwd string) error {
+	_, err := config.Init(cwd)
+	return err
 }
 
 // runPull は common + 指定Target の Entry を dest から Store へ回収する。


### PR DESCRIPTION
カレント直下にコメント付きの mdots.toml 雛形を作る mdots init を追加する。雛形は見て使い方が分かる日本語コメント＋サンプル3件（common／win／win＋wsl）で Load/Validate を通る。既存ありは mdots.toml already exists in <cwd> で exit 1、--force なし。成功時は created mdots.toml を出す。テスト: go test ./... -count=1、go vet 通過。