### PR TITLE
feat: target指定を配列のみにし不要な仕様を減らす

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ mise use github:mogurastore/mdots@latest
 Store（管理リポジトリ）の直下に `mdots.toml` を置く。
 `mdots init` でコメント付き雛形を作れる。
 `src` は Store 相対のファイルパス、`dest` は `~` 展開される配置先パス、
-`target` は省略時 common 扱いの自由文字列（例: `win`, `wsl`）。
+`target` は省略時 common 扱いの文字列配列（例: `["win"]`, `["win", "wsl"]`）。
 
 ```toml
 # <Store>/mdots.toml
@@ -35,7 +35,7 @@ dest = "~/.vimrc"
 [[entries]]
 src = "wezterm.lua"
 dest = "~/.config/wezterm/wezterm.lua"
-target = "win"
+target = ["win"]
 
 [[entries]]
 src = "shared.conf"

--- a/config/config.go
+++ b/config/config.go
@@ -16,31 +16,29 @@ type Config struct {
 
 // Entry は1つの管理対象を表す src/dest ペア。
 // src は Store 相対のファイルパス、dest は ~ 展開される配置先パス。
-// Target は適用先を識別する自由文字列。省略時は common として扱う。
+// Target は適用先を識別する自由文字列の配列。省略時は common として扱う。
+// 単一指定も1要素配列で書く（例: ["win"]）。
 type Entry struct {
 	Src    string     `toml:"src"`
 	Dest   string     `toml:"dest"`
 	Target TargetList `toml:"target,omitempty"`
 }
 
-// TargetList は string | string[] を受け付ける Target の集合。
+// TargetList は string[] を受け付ける Target の集合。
 type TargetList []string
 
-// UnmarshalTOML は string | string[] の両方を受け付ける。
+// UnmarshalTOML は string[] のみを受け付ける。単一指定は1要素配列で書く。
 func (t *TargetList) UnmarshalTOML(value interface{}) error {
 	switch v := value.(type) {
 	case nil:
 		*t = nil
-		return nil
-	case string:
-		*t = TargetList{v}
 		return nil
 	case []interface{}:
 		out := make(TargetList, 0, len(v))
 		for _, item := range v {
 			s, ok := item.(string)
 			if !ok {
-				return fmt.Errorf("target must be string or string[]")
+				return fmt.Errorf("target must be string[]")
 			}
 			out = append(out, s)
 		}
@@ -50,7 +48,7 @@ func (t *TargetList) UnmarshalTOML(value interface{}) error {
 		*t = TargetList(v)
 		return nil
 	default:
-		return fmt.Errorf("target must be string or string[]")
+		return fmt.Errorf("target must be string[]")
 	}
 }
 
@@ -166,7 +164,7 @@ const Template = `# mdots.toml — Store（このファイルがあるディレ�
 # Entry（1つの管理対象）:
 #   src    = Store相対のファイルパス
 #   dest   = 配置先パス（~ / ~/... はホームに展開）
-#   target = 省略時 common。--target 未指定時は common のみ、指定時は common + 指定Target が対象
+#   target = 配列で指定（省略時 common）。単一も ["win"] のように書く。--target 未指定時は common のみ、指定時は common + 指定Target が対象
 #
 # コメントを外して使う。まず common の1件から始めるのがおすすめ。
 #
@@ -177,7 +175,7 @@ const Template = `# mdots.toml — Store（このファイルがあるディレ�
 # [[entries]]
 # src = "wezterm.lua"
 # dest = "~/.config/wezterm/wezterm.lua"
-# target = "win"
+# target = ["win"]
 #
 # [[entries]]
 # src = "shared.conf"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,9 +46,9 @@ func TestFilterByTarget(t *testing.T) {
 }
 
 // Seam: config パッケージ公開境界 (Store の mdots.toml 読込・validation)
-// Entry の src/dest 必須と target の string | string[] を外部挙動で検証する。
+// Entry の src/dest 必須と target の string[] を外部挙動で検証する。
 func TestLoadStoreConfig(t *testing.T) {
-	t.Run("stringと配列のTargetを読み込める", func(t *testing.T) {
+	t.Run("配列のTargetを読み込める", func(t *testing.T) {
 		dir := t.TempDir()
 		p := filepath.Join(dir, "mdots.toml")
 		body := "[[entries]]\n" +
@@ -58,7 +58,7 @@ func TestLoadStoreConfig(t *testing.T) {
 			"[[entries]]\n" +
 			"src = \"wezterm.lua\"\n" +
 			"dest = \"~/.config/wezterm/wezterm.lua\"\n" +
-			"target = \"win\"\n" +
+			"target = [\"win\"]\n" +
 			"\n" +
 			"[[entries]]\n" +
 			"src = \"shared.conf\"\n" +
@@ -68,7 +68,7 @@ func TestLoadStoreConfig(t *testing.T) {
 			"[[entries]]\n" +
 			"src = \"common.conf\"\n" +
 			"dest = \"~/.config/common.conf\"\n" +
-			"target = \"common\"\n"
+			"target = [\"common\"]\n"
 		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -93,6 +93,7 @@ func TestLoadStoreConfig(t *testing.T) {
 			"src欠落":     "[[entries]]\ndest = \"~/.a\"\n",
 			"dest欠落":    "[[entries]]\nsrc = \"a\"\n",
 			"target型不正": "[[entries]]\nsrc = \"a\"\ndest = \"~/.a\"\ntarget = 123\n",
+			"target文字列は不正": "[[entries]]\nsrc = \"a\"\ndest = \"~/.a\"\ntarget = \"win\"\n",
 		}
 		for name, body := range cases {
 			p := filepath.Join(dir, "mdots.toml")

--- a/main_test.go
+++ b/main_test.go
@@ -63,8 +63,8 @@ func TestPushWithTargetRepresentative(t *testing.T) {
 		},
 		nil,
 		"[[entries]]\nsrc = \"common.conf\"\ndest = \"~/.common.conf\"\n"+
-			"[[entries]]\nsrc = \"win.conf\"\ndest = \"~/.win.conf\"\ntarget = \"win\"\n"+
-			"[[entries]]\nsrc = \"wsl.conf\"\ndest = \"~/.wsl.conf\"\ntarget = \"wsl\"\n",
+			"[[entries]]\nsrc = \"win.conf\"\ndest = \"~/.win.conf\"\ntarget = [\"win\"]\n"+
+			"[[entries]]\nsrc = \"wsl.conf\"\ndest = \"~/.wsl.conf\"\ntarget = [\"wsl\"]\n",
 	)
 
 	if code := run([]string{"push", "--target", "win"}, store); code != 0 {


### PR DESCRIPTION
targetの文字列指定を廃止し、配列のみ受け付けるように変更。単一指定は1要素配列で書く。

- config: UnmarshalTOMLからstringケース削除、エラー文言を target must be string[] に統一
- Template/READMEの例を配列表記に更新
- テストを配列前提に更新し、文字列指定の拒否ケースを追加