### PR TITLE
refactor: version表示を枠組み標準に寄せ旧短縮形と独自サブコマンドを廃止する

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -101,8 +101,8 @@ type runner struct {
 func Run(args []string, cwd, version string, ex Executor, stdout, stderr io.Writer) int {
 	r := &runner{version: version, exec: ex, cwd: cwd, stdout: stdout, stderr: stderr}
 
-	// 先頭トークンの事前振り分け。従来の自前解析は先頭トークンだけで
-	// help/version/unknown を確定させていたため、その優先順位を凍結値のまま保つ。
+	// 先頭トークンの事前振り分け。help/unknown は凍結値のまま保ち、
+	// version は枠組み標準に任せるため事前振り分けしない。
 	// push/pull の詳細なフラグ解釈は宣言ツリーに任せる。
 	if len(args) == 0 {
 		fmt.Fprint(stderr, GlobalHelp)
@@ -112,11 +112,10 @@ func Run(args []string, cwd, version string, ex Executor, stdout, stderr io.Writ
 	case "--help", "-h":
 		fmt.Fprint(stdout, GlobalHelp)
 		return 0
-	case "--version", "-V", "version":
-		fmt.Fprintf(stdout, "mdots %s\n", version)
-		return 0
-	case "push", "pull", "init":
-		// 宣言ツリーへ進む。
+	case "--version", "-v", "-V", "push", "pull", "init":
+		// 宣言ツリーへ進む。--version/-v は標準の version 表示、
+		// -V は標準の未知フラグ扱いになる。
+		// "version" は独自サブコマンドを廃止したため default の未知扱いに落とす。
 	default:
 		fmt.Fprintf(stderr, "unknown command: %s\n", args[0])
 		fmt.Fprint(stderr, GlobalHelp)
@@ -155,10 +154,10 @@ func (r *runner) newCommand() *cliv3.Command {
 		Name:    "mdots",
 		Usage:   "dotfilesをファイルコピー（非symlink）で管理するCLI。",
 		Version: r.version,
-		// 組み込みの version 表示・help サブコマンドは表面にないため抑止する。
-		// version 表示と unknown 時の扱いは Run の事前振り分けが凍結値で行う。
-		HideVersion:                   true,
-		HideHelpCommand:               true,
+		// 組み込みの help サブコマンドは表面にないため抑止する。
+		// version 表示は枠組み標準（--version/-v）に任せる。
+		// unknown 時の扱いは Run の事前振り分けが凍結値で行う。
+		HideHelpCommand: true,
 		Writer:                        r.stdout,
 		ErrWriter:                     r.stderr,
 		CustomRootCommandHelpTemplate: GlobalHelp,
@@ -194,18 +193,6 @@ func (r *runner) newCommand() *cliv3.Command {
 				CustomHelpTemplate: InitHelp,
 				OnUsageError:       r.usageError(InitHelp),
 				Action:             r.initAction,
-			},
-			{
-				// version サブコマンドの宣言。従来の先頭トークン優先を保つため
-				// Run の事前振り分けが先に処理するが、ツリーの完全性のため宣言を残す。
-				Name:               "version",
-				Usage:              "バージョンを表示する",
-				CustomHelpTemplate: GlobalHelp,
-				SkipFlagParsing:    true,
-				Action: func(context.Context, *cliv3.Command) error {
-					fmt.Fprintf(r.stdout, "mdots %s\n", r.version)
-					return nil
-				},
 			},
 		},
 	}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -97,16 +97,46 @@ func TestCliNoArgsPrintsGlobalHelpToStderr(t *testing.T) {
 }
 
 func TestCliVersion(t *testing.T) {
-	for _, args := range [][]string{{"--version"}, {"-V"}, {"version"}} {
+	for _, args := range [][]string{{"--version"}, {"-v"}} {
 		ex := &fakeExecutor{}
 		code, out, _ := runCli(t, ex, args)
 		if code != 0 {
 			t.Fatalf("Run(%v) exit = %d, want 0", args, code)
 		}
-		if !strings.Contains(out, "v0.0.0-test") {
-			t.Errorf("Run(%v): output should contain version, got %q", args, out)
+		if !strings.Contains(out, "mdots version v0.0.0-test") {
+			t.Errorf("Run(%v): output should contain standard version, got %q", args, out)
 		}
 	}
+}
+
+func TestCliVersionOldFormsAreUnknown(t *testing.T) {
+	t.Run("-Vは標準の未知フラグ扱い", func(t *testing.T) {
+		ex := &fakeExecutor{}
+		code, out, errOut := runCli(t, ex, []string{"-V"})
+		if code == 0 {
+			t.Fatal("Run(-V): exit = 0, want non-zero")
+		}
+		if strings.Contains(out, "v0.0.0-test") {
+			t.Errorf("Run(-V): must not show version, got %q", out)
+		}
+		if !strings.Contains(errOut, "Incorrect Usage") {
+			t.Errorf("stderr should contain Incorrect Usage, got %q", errOut)
+		}
+	})
+
+	t.Run("versionは未知コマンド扱い", func(t *testing.T) {
+		ex := &fakeExecutor{}
+		code, out, errOut := runCli(t, ex, []string{"version"})
+		if code == 0 {
+			t.Fatal("Run(version): exit = 0, want non-zero")
+		}
+		if strings.Contains(out, "v0.0.0-test") {
+			t.Errorf("Run(version): must not show version, got %q", out)
+		}
+		if !strings.Contains(errOut, "unknown command: version") {
+			t.Errorf("stderr should contain unknown command: version, got %q", errOut)
+		}
+	})
 }
 
 func TestCliUnknownCommand(t *testing.T) {


### PR DESCRIPTION
Closes #40

## 変更
- cli/cli.go: HideVersion除去で --version/-v を枠組み標準に有効化
- cli/cli.go: versionサブコマンド宣言を除去
- cli/cli.go: 事前振り分けから旧version表示を削除し、--version/-v/-Vを宣言ツリーへ、versionは未知扱いへ
- cli/cli_test.go: TestCliVersionを標準文面（mdots version v0.0.0-test）に更新し、旧形式の未知扱いテストを追加

## 検証
- go vet ./... 通過
- go test ./cli/ -count=1 全緑
- go test ./... -count=1 全緑

## レビュー
- Standards: 指摘なし（弱い表現の示唆のみ）
- Spec: version未知のexit 3未達1件（段階移行として許容、最終標準化は #42 に委譲）