### PR TITLE
refactor: usageとunknownの扱いを枠組み既定に寄せて削減を完成させる

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,8 +4,7 @@
 // --target/--dry-run を定義する）。pflagのみによる自前解析は段階移行の予備案
 // として残すが、既定は v3 とする（spec #24 の Implementation Decisions による）。
 //
-// CLI表面（help/version時の文面・exit）は枠組み既定に寄せる。
-// unknown時の文面・exitは凍結値のまま残し（#42で既定化）、
+// CLI表面（help/version/unknown/usage時の文面・exit）は枠組み既定に寄せる。
 // 内部実行は Executor 委譲とし、エントリは薄く保つ。
 package cli
 
@@ -14,59 +13,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	cliv3 "github.com/urfave/cli/v3"
 )
-
-const GlobalHelp = `usage: mdots <push|pull|init> [options]
-
-dotfilesをファイルコピー（非symlink）で管理するCLI。
-Store（mdots.toml を含む管理リポジトリのルート）の直下で実行する。mdots.toml はカレント直下のみ参照する。
-
-commands:
-  push  Storeからdestへファイルをコピーする
-  pull  destからStoreへファイルを回収する
-  init  Storeにmdots.toml雛形を作る
-
-global options:
-  -h, --help     使い方を表示する
-  --version      バージョンを表示する
-
-run 'mdots <command> --help' for command-specific help.
-`
-
-const PushHelp = `usage: mdots push [--target <name>] [--dry-run]
-
-Storeからdestへファイルをコピーする。
---target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
-
-options:
-  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
-  --dry-run        実際に書き込まず差分相当を出力する。差分ありは exit 1
-  -h, --help       使い方を表示する
-`
-
-const PullHelp = `usage: mdots pull [--target <name>] [--dry-run]
-
-destからStoreへファイルを回収する。
---target 未指定時はcommonのみ、指定時は common + 指定Target が対象。
-
-options:
-  --target <name>  対象Target (例: win, wsl)。--target=<name> 形式も可
-  --dry-run        実際に書き込まず差分相当を出力する。差分ありは exit 1
-  -h, --help       使い方を表示する
-`
-
-const InitHelp = `usage: mdots init
-
-Storeにmdots.toml雛形を作る。
-カレント直下に雛形を作り、見て使い方が分かるコメントとサンプルを含む。
-既にあるときは mdots.toml already exists in <cwd> と表示し exit 1 になる。
-
-options:
-  -h, --help       使い方を表示する
-`
 
 // Executor は push/pull/init の内部実行系への委譲口である。
 // 表面（文面・exit）は本パッケージが保ち、副作用のある処理だけを委譲する。
@@ -91,45 +40,31 @@ type runner struct {
 	cwd     string
 	stdout  io.Writer
 	stderr  io.Writer
-	// cmdArgs はサブコマンド名より後ろの生トークンである。未知フラグの報告時に
-	// フレームワークが正規化した名前から元の綴り（-V と --V の区別など）を復元する。
-	cmdArgs []string
 }
 
 // Run は CLI表面の入口である。args は os.Args[1:] 相当、cwd は実行ディレクトリ。
 // 戻り値はプロセスの exit code。
+// フラグ解釈・help/version/unknown の表面は枠組み既定に任せ、
+// 空値・余剰引数の拒否だけを Action 側で残す。
 func Run(args []string, cwd, version string, ex Executor, stdout, stderr io.Writer) int {
 	r := &runner{version: version, exec: ex, cwd: cwd, stdout: stdout, stderr: stderr}
 
-	// 先頭トークンの事前振り分け。help（--help/-h・引数なし）は枠組み既定に任せるため
-	// 事前振り分けしない。version は枠組み標準に任せるため事前振り分けしない。
-	// push/pull の詳細なフラグ解釈は宣言ツリーに任せる。
-	// unknown は凍結値のまま保つ（#42で既定化する）。
-	if len(args) > 0 {
-		switch args[0] {
-		case "--help", "-h", "--version", "-v", "-V", "push", "pull", "init":
-			// 宣言ツリーへ進む。--help/-h・引数なしは既定のhelp表示、
-			// --version/-v は標準の version 表示、
-			// -V は標準の未知フラグ扱いになる。
-			// "version" は独自サブコマンドを廃止したため default の未知扱いに落とす。
-		default:
-			fmt.Fprintf(stderr, "unknown command: %s\n", args[0])
-			fmt.Fprint(stderr, GlobalHelp)
-			return 1
-		}
-	}
-
 	cmd := r.newCommand()
-	if len(args) > 0 {
-		r.cmdArgs = args[1:]
-	}
 	if err := cmd.Run(context.Background(), append([]string{"mdots"}, args...)); err != nil {
 		var ee *exitError
 		if errors.As(err, &ee) {
 			return ee.code
 		}
-		// 想定外のエラーは文面を出して exit 1（表面の想定経路はすべて exitError）。
-		fmt.Fprintln(stderr, err)
+		var ec cliv3.ExitCoder
+		if errors.As(err, &ec) {
+			// unknown command 時の既定（No help topic、exit 3）。
+			// 枠組み既定の ExitErrHandler はグローバル ErrWriter に出すため、
+			// 注入先 stderr に出し直してテスト同一プロセス性を保つ。
+			fmt.Fprintln(stderr, ec.Error())
+			return ec.ExitCode()
+		}
+		// フラグ解釈失敗時の既定（Incorrect Usage＋help）は枠組み側で
+		// 注入先に表示済みのため、ここでは文面を出さず exit 1 にする。
 		return 1
 	}
 	return 0
@@ -146,20 +81,22 @@ func dryRunFlag() cliv3.Flag {
 	return &cliv3.BoolFlag{Name: "dry-run", Usage: "実際に書き込まず差分相当を出力する。差分ありは exit 1"}
 }
 
-// newCommand はコマンド宣言ツリーを組み立てる。help表示は枠組み既定の
-// テンプレートに任せ、--target/--dry-run の定義だけを宣言する。
+// newCommand はコマンド宣言ツリーを組み立てる。help/usage/unknown表示は
+// 枠組み既定に任せ、--target/--dry-run の定義だけを宣言する。
+// フラグ解釈失敗時（未知フラグ・値なし）は OnUsageError 既定（nil）の
+// Incorrect Usage＋help表示になる。
 func (r *runner) newCommand() *cliv3.Command {
 	return &cliv3.Command{
 		Name:    "mdots",
 		Usage:   "dotfilesをファイルコピー（非symlink）で管理するCLI。",
 		Version: r.version,
 		// 組み込みの help サブコマンドは表面にないため抑止する。
-		// version 表示・help表示は枠組み標準に任せる。
-		// unknown 時の扱いは Run の事前振り分けが凍結値で行う（#42で既定化する）。
+		// version 表示・help表示・unknown 時の扱いは枠組み標準に任せる。
 		HideHelpCommand: true,
 		Writer:          r.stdout,
 		ErrWriter:       r.stderr,
-		// 想定外の出力（Incorrect Usage 等）を抑え、文面は自前の凍結値のみにする。
+		// ExitCoder（unknown command 時の exit 3等）で os.Exit しないよう
+		// 無操作化し、Run 側で exit code を回収する（テスト同一プロセス性のため）。
 		ExitErrHandler: func(context.Context, *cliv3.Command, error) {},
 		Commands: []*cliv3.Command{
 			{
@@ -169,8 +106,7 @@ func (r *runner) newCommand() *cliv3.Command {
 					targetFlag(),
 					dryRunFlag(),
 				},
-				OnUsageError: r.usageError(PushHelp),
-				Action:       r.pushAction,
+				Action: r.pushAction,
 			},
 			{
 				Name:  "pull",
@@ -179,83 +115,46 @@ func (r *runner) newCommand() *cliv3.Command {
 					targetFlag(),
 					dryRunFlag(),
 				},
-				OnUsageError: r.usageError(PullHelp),
-				Action:       r.pullAction,
+				Action: r.pullAction,
 			},
 			{
-				Name:         "init",
-				Usage:        "Storeにmdots.toml雛形を作る",
-				OnUsageError: r.usageError(InitHelp),
-				Action:       r.initAction,
+				Name:   "init",
+				Usage:  "Storeにmdots.toml雛形を作る",
+				Action: r.initAction,
 			},
 		},
 	}
 }
 
-// usageError はフラグ解釈失敗時（未知フラグ・--target の値不足）の表面を凍結値で出す。
-//
-// なお従来の自前解析との優先順位の違いは残る。--help と不正トークンの併用時は help が不正より前にある場合に限り help 優先となり（逆順は usageError）、
-// bare `--` はフラグ区切りとして扱う。いずれも exit 1 である点は従来通り。
-func (r *runner) usageError(commandHelp string) cliv3.OnUsageErrorFunc {
-	return func(_ context.Context, _ *cliv3.Command, err error, _ bool) error {
-		msg := err.Error()
-		switch {
-		case strings.Contains(msg, "needs an argument"):
-			// --target の値がない場合。対象フラグは target のみ。
-			msg = "missing value for --target"
-		case strings.HasPrefix(msg, "flag provided but not defined: -"):
-			name := strings.TrimLeft(strings.TrimPrefix(msg, "flag provided but not defined: -"), "-")
-			msg = "unknown argument: " + r.rawFlagToken(name)
-		}
-		fmt.Fprintln(r.stderr, msg)
-		fmt.Fprint(r.stderr, commandHelp)
-		return &exitError{code: 1}
-	}
-}
-
-// rawFlagToken は報告されたフラグ名に対応する元の綴りを生トークンから探す。
-// 見つからなければ --<name> 形式にフォールバックする。
-func (r *runner) rawFlagToken(name string) string {
-	for _, tok := range r.cmdArgs {
-		base := strings.TrimLeft(tok, "-")
-		if i := strings.Index(base, "="); i >= 0 {
-			base = base[:i]
-		}
-		if base == name {
-			return tok
-		}
-	}
-	return "--" + name
-}
-
-// argError は余分な位置引数の表面を凍結値で出す。
-func (r *runner) argError(commandHelp, arg string) error {
+// argError は余分な位置引数を拒否する。
+// なお --help と不正トークンの併用時は help が不正より前にある場合に限り
+// help 優先となり（逆順は利用エラー）、bare `--` 以降は位置引数として
+// ここで拒否される。いずれも exit 1 である。
+func (r *runner) argError(arg string) error {
 	fmt.Fprintf(r.stderr, "unknown argument: %s\n", arg)
-	fmt.Fprint(r.stderr, commandHelp)
 	return &exitError{code: 1}
 }
 
-func (r *runner) targetOf(cmd *cliv3.Command, commandHelp string) (string, error) {
+func (r *runner) targetOf(cmd *cliv3.Command) (string, error) {
 	target := cmd.String("target")
 	if cmd.IsSet("target") && target == "" {
 		// --target= のように空値で指定された場合。
 		fmt.Fprintln(r.stderr, "missing value for --target")
-		fmt.Fprint(r.stderr, commandHelp)
 		return "", &exitError{code: 1}
 	}
 	return target, nil
 }
 
 // targetArgs は余分な位置引数の検査と --target の解釈をまとめて行う。
-func (r *runner) targetArgs(cmd *cliv3.Command, commandHelp string) (string, error) {
+func (r *runner) targetArgs(cmd *cliv3.Command) (string, error) {
 	if cmd.Args().Present() {
-		return "", r.argError(commandHelp, cmd.Args().First())
+		return "", r.argError(cmd.Args().First())
 	}
-	return r.targetOf(cmd, commandHelp)
+	return r.targetOf(cmd)
 }
 
 func (r *runner) pushAction(_ context.Context, cmd *cliv3.Command) error {
-	target, err := r.targetArgs(cmd, PushHelp)
+	target, err := r.targetArgs(cmd)
 	if err != nil {
 		return err
 	}
@@ -273,7 +172,7 @@ func (r *runner) pushAction(_ context.Context, cmd *cliv3.Command) error {
 }
 
 func (r *runner) pullAction(_ context.Context, cmd *cliv3.Command) error {
-	target, err := r.targetArgs(cmd, PullHelp)
+	target, err := r.targetArgs(cmd)
 	if err != nil {
 		return err
 	}
@@ -292,7 +191,7 @@ func (r *runner) pullAction(_ context.Context, cmd *cliv3.Command) error {
 
 func (r *runner) initAction(_ context.Context, cmd *cliv3.Command) error {
 	if cmd.Args().Present() {
-		return r.argError(InitHelp, cmd.Args().First())
+		return r.argError(cmd.Args().First())
 	}
 	if err := r.exec.Init(r.cwd); err != nil {
 		fmt.Fprintln(r.stderr, err)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -130,14 +130,14 @@ func TestCliVersionOldFormsAreUnknown(t *testing.T) {
 	t.Run("versionは未知コマンド扱い", func(t *testing.T) {
 		ex := &fakeExecutor{}
 		code, out, errOut := runCli(t, ex, []string{"version"})
-		if code == 0 {
-			t.Fatal("Run(version): exit = 0, want non-zero")
+		if code != 3 {
+			t.Fatalf("Run(version): exit = %d, want 3", code)
 		}
 		if strings.Contains(out, "v0.0.0-test") {
 			t.Errorf("Run(version): must not show version, got %q", out)
 		}
-		if !strings.Contains(errOut, "unknown command: version") {
-			t.Errorf("stderr should contain unknown command: version, got %q", errOut)
+		if !strings.Contains(errOut, "No help topic for 'version'") {
+			t.Errorf("stderr should contain No help topic for 'version', got %q", errOut)
 		}
 	})
 }
@@ -145,24 +145,67 @@ func TestCliVersionOldFormsAreUnknown(t *testing.T) {
 func TestCliUnknownCommand(t *testing.T) {
 	ex := &fakeExecutor{}
 	code, _, errOut := runCli(t, ex, []string{"frobnicate"})
-	if code != 1 {
-		t.Fatalf("Run(unknown) exit = %d, want 1", code)
+	if code != 3 {
+		t.Fatalf("Run(unknown) exit = %d, want 3", code)
 	}
-	for _, want := range []string{"unknown command: frobnicate", "usage:"} {
-		if !strings.Contains(errOut, want) {
-			t.Errorf("stderr should contain %q, got %q", want, errOut)
-		}
+	if !strings.Contains(errOut, "No help topic for 'frobnicate'") {
+		t.Errorf("stderr should contain No help topic for 'frobnicate', got %q", errOut)
 	}
 }
 
 func TestCliDiffIsRemoved(t *testing.T) {
 	ex := &fakeExecutor{}
 	code, _, errOut := runCli(t, ex, []string{"diff"})
-	if code == 0 {
-		t.Fatal("Run(diff): exit = 0, want non-zero")
+	if code != 3 {
+		t.Fatalf("Run(diff): exit = %d, want 3", code)
 	}
-	if !strings.Contains(errOut, "unknown command: diff") {
-		t.Errorf("stderr should contain unknown command: diff, got %q", errOut)
+	if !strings.Contains(errOut, "No help topic for 'diff'") {
+		t.Errorf("stderr should contain No help topic for 'diff', got %q", errOut)
+	}
+}
+
+func TestCliStandardUsageError(t *testing.T) {
+	for _, args := range [][]string{
+		{"push", "--target"},
+		{"pull", "--target"},
+		{"push", "--unknown"},
+		{"pull", "--unknown"},
+	} {
+		ex := &fakeExecutor{}
+		code, out, errOut := runCli(t, ex, args)
+		if code == 0 {
+			t.Errorf("Run(%v): exit = 0, want non-zero", args)
+		}
+		if !strings.Contains(errOut, "Incorrect Usage") {
+			t.Errorf("Run(%v): stderr should contain Incorrect Usage, got %q", args, errOut)
+		}
+		if !strings.Contains(out, "USAGE:") {
+			t.Errorf("Run(%v): stdout should contain USAGE:, got %q", args, out)
+		}
+		if ex.pushCalls+ex.pullCalls+ex.initCalls+ex.pushDryCalls+ex.pullDryCalls != 0 {
+			t.Errorf("Run(%v): executor must not run", args)
+		}
+	}
+}
+
+func TestCliEmptyAndExtraArgsStillRejected(t *testing.T) {
+	for _, args := range [][]string{
+		{"push", "--target="},
+		{"pull", "--target="},
+		{"push", "extra-positional"},
+		{"pull", "extra-positional"},
+		{"init", "extra"},
+		{"push", "--", "--target", "win"},
+		{"pull", "--", "--target", "win"},
+	} {
+		ex := &fakeExecutor{}
+		code, _, _ := runCli(t, ex, args)
+		if code == 0 {
+			t.Errorf("Run(%v): exit = 0, want non-zero", args)
+		}
+		if ex.pushCalls+ex.pullCalls+ex.initCalls+ex.pushDryCalls+ex.pullDryCalls != 0 {
+			t.Errorf("Run(%v): executor must not run", args)
+		}
 	}
 }
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -69,11 +69,11 @@ func TestDryRunIntegration(t *testing.T) {
 func TestDiffIsRemoved(t *testing.T) {
 	store, _ := setupStoreWithHome(t, nil, nil, "")
 	var out, errOut bytes.Buffer
-	if code := runWithWriters([]string{"diff"}, store, &out, &errOut); code == 0 {
-		t.Error("run(diff): exit = 0, want non-zero")
+	if code := runWithWriters([]string{"diff"}, store, &out, &errOut); code != 3 {
+		t.Errorf("run(diff): exit = %d, want 3", code)
 	}
-	if !strings.Contains(errOut.String(), "unknown command: diff") {
-		t.Errorf("stderr should contain unknown command: diff, got %q", errOut.String())
+	if !strings.Contains(errOut.String(), "No help topic for 'diff'") {
+		t.Errorf("stderr should contain No help topic for 'diff', got %q", errOut.String())
 	}
 }
 


### PR DESCRIPTION
Closes #42

## 概要
独自のusage正規化（usageError・rawFlagToken・OnUsageError）と事前振り分け残部（unknown分岐）を捨て、urfave/cli v3既定の利用エラー表示と未知扱いに寄せる。凍結help定数（GlobalHelp/PushHelp/PullHelp/InitHelp）を削除し、空値・余剰引数の拒否（targetOf/targetArgs/argError）だけ残す。

## 挙動
- 値なし・未知フラグ時: 標準の Incorrect Usage＋help表示（stderr＋stdout分離）、exit 1
- 未知コマンド時: 標準の No help topic、exit 3（注入先stderrに再出力しテスト同一プロセス性を維持）
- 空値target・余剰位置引数・区切り後引数: 引き続き拒否し非zero、Executor未実行
- push/pull/init正常系・dry-run委譲・実行エラー伝播は不変

## 検証
- go vet ./... clean
- go test ./... 全緑（cli表面・統合回帰含む）