### PR TITLE
docs: init雛形のtargetサンプルを1パターンに整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ mise use github:mogurastore/mdots@latest
 Store（管理リポジトリ）の直下に `mdots.toml` を置く。
 `mdots init` でコメント付き雛形を作れる。
 `src` は Store 相対のファイルパス、`dest` は `~` 展開される配置先パス、
-`target` は省略時 common 扱いの文字列配列（例: `["win"]`, `["win", "wsl"]`）。
+`target` は省略時 common 扱いの文字列配列（例: `["win"]`。複数指定も可）。
 
 ```toml
 # <Store>/mdots.toml
@@ -36,11 +36,6 @@ dest = "~/.vimrc"
 src = "wezterm.lua"
 dest = "~/.config/wezterm/wezterm.lua"
 target = ["win"]
-
-[[entries]]
-src = "shared.conf"
-dest = "~/.config/shared.conf"
-target = ["win", "wsl"]
 ```
 
 ```sh

--- a/config/config.go
+++ b/config/config.go
@@ -164,7 +164,7 @@ const Template = `# mdots.toml — Store（このファイルがあるディレ�
 # Entry（1つの管理対象）:
 #   src    = Store相対のファイルパス
 #   dest   = 配置先パス（~ / ~/... はホームに展開）
-#   target = 配列で指定（省略時 common）。単一も ["win"] のように書く。--target 未指定時は common のみ、指定時は common + 指定Target が対象
+#   target = 配列で指定（省略時 common）。単一も ["win"] のように書く。複数指定も可（例: ["win", "wsl"]）。--target 未指定時は common のみ、指定時は common + 指定Target が対象
 #
 # コメントを外して使う。まず common の1件から始めるのがおすすめ。
 #
@@ -176,11 +176,6 @@ const Template = `# mdots.toml — Store（このファイルがあるディレ�
 # src = "wezterm.lua"
 # dest = "~/.config/wezterm/wezterm.lua"
 # target = ["win"]
-#
-# [[entries]]
-# src = "shared.conf"
-# dest = "~/.config/shared.conf"
-# target = ["win", "wsl"]
 `
 
 // Init は指定ディレクトリ直下に mdots.toml 雛形を作り、作ったパスを返す。


### PR DESCRIPTION
initが作る雛形とREADMEの最小サンプルから複数指定例のshared.confを削除し、単一["win"]のみ残す。複数指定可の旨はコメントで補足。生成物はLoadを通ることをgo testで確認。