### PR TITLE
fix: pullのdry-run差分をdestからStore方向に反転する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,5 +33,5 @@ Storeにmdots.toml雛形を作る操作。
 _Avoid_: create, new, setup
 
 **dry-run**:
-push/pullの差分相当を書き込まず出力する操作。
+pushはStoreからdestへ、pullはdestからStoreへの適用予定差分を書き込まず出力する操作。
 _Avoid_: diff, preview

--- a/docs/adr/0007-pull-dry-run-direction.md
+++ b/docs/adr/0007-pull-dry-run-direction.md
@@ -1,0 +1,3 @@
+# pullのdry-run差分をdest→Store方向に反転する
+
+0004では両方存在時にpush/pullが同じunified diffを出すと決めたが、copyが逆向きなのにプレビューが同じではpushで+追加に見えた差分がpullでも+追加に見えて混乱するため、pullの両方存在時は引数ごと入れ替えてdest→Store方向に出すと決めた。欠落・エラー扱いと着色・ハンクは従来通りで、go-deltaへの委譲は変えない。

--- a/sync/direction_test.go
+++ b/sync/direction_test.go
@@ -1,0 +1,38 @@
+package sync
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mogurastore/mdots/config"
+)
+
+// Seam: sync パッケージ公開境界 (push/pull の dry-run 方向)
+// 同一fixtureで push と pull が対称反転することを検証する。
+func TestDryRunPushPullDirectionSymmetric(t *testing.T) {
+	store, destRoot := setupSyncDirs(t)
+
+	writeTestFile(t, filepath.Join(store, "a"), "old\n")
+	dest := filepath.Join(destRoot, "a")
+	writeTestFile(t, dest, "new\n")
+	entries := []config.Entry{{Src: "a", Dest: dest}}
+
+	pushOut, _, err := DryRunPushWithColor(store, entries, ColorNever)
+	if err != nil {
+		t.Fatalf("DryRunPush error: %v", err)
+	}
+	pullOut, _, err := DryRunPullWithColor(store, entries, ColorNever)
+	if err != nil {
+		t.Fatalf("DryRunPull error: %v", err)
+	}
+	if pushOut == pullOut {
+		t.Errorf("push/pull outputs must differ for same fixture,\ngot push=%q pull=%q", pushOut, pullOut)
+	}
+	if !strings.Contains(pushOut, "--- a\n") || !strings.Contains(pushOut, "+++ "+dest+"\n") {
+		t.Errorf("push must be Store->dest headers, got %q", pushOut)
+	}
+	if !strings.Contains(pullOut, "--- "+dest+"\n") || !strings.Contains(pullOut, "+++ a\n") {
+		t.Errorf("pull must be dest->Store headers, got %q", pullOut)
+	}
+}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -98,7 +98,9 @@ func writeNewFileNotice(sb *strings.Builder, srcLabel, destLabel, body string, u
 }
 
 // diffCore は dry-run 系の単一の差分コアである。
-// 両方存在する Entry は go-delta による inline diff を出し、不在の扱いだけを policy で切り替える。
+// 両方存在する Entry は go-delta による inline diff を出す。向きは push が
+// Store→dest、pull が dest→Store で、pull時は引数ごと入れ替えて反転させる。
+// 不在の扱いだけを policy で切り替える。
 func diffCore(storeRoot string, entries []config.Entry, policy missingPolicy, colorMode string) (string, bool, error) {
 	op := policy.opLabel()
 	useColor := resolveUseColor(colorMode)
@@ -150,7 +152,13 @@ func diffCore(storeRoot string, entries []config.Entry, policy missingPolicy, co
 				return "", false, fmt.Errorf("%s %s: Store src is a directory: %s", op, e.Src, srcPath)
 			}
 		}
-		d, same, err := diffContent(srcPath, destPath, e.Src, e.Dest, colorMode)
+		var d string
+		var same bool
+		if policy == policyPullDryRun {
+			d, same, err = diffContent(destPath, srcPath, e.Dest, e.Src, colorMode)
+		} else {
+			d, same, err = diffContent(srcPath, destPath, e.Src, e.Dest, colorMode)
+		}
 		if err != nil {
 			return "", false, fmt.Errorf("%s %s: %w", op, e.Src, err)
 		}


### PR DESCRIPTION
同一fixtureでpush/pullが同じ差分になっていたため、pullの両方存在時をdest→Store方向に反転する。欠落・エラー扱いと着色・ハンクは維持し、go-delta委譲は変えない。CONTEXT.md更新、ADR-0007追加、対称テスト追加。