### PR TITLE
fix: diffの極性をdest→Storeに反転しpush追加分を+表示にする

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,5 +33,5 @@ Storeにmdots.toml雛形を作る操作。
 _Avoid_: create, new, setup
 
 **diff**:
-Storeとdestの差分をStore→dest方向に固定して書き込まず出力する操作。
+Storeとdestの差分をdest→Store方向に固定して書き込まず出力する操作。
 _Avoid_: dry-run, preview

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ target = ["win"]
 mdots push              # common のみを Store から dest へコピー
 mdots push --target win # common + win を対象にする
 mdots pull --target win # dest から Store へ回収する
-mdots diff              # 差分を Store→dest方向に出力する（差分なし: exit 0、差分あり: exit 1）
+mdots diff              # 差分を dest→Store方向に出力する（差分なし: exit 0、差分あり: exit 1。+はpushで追加される行）
 ```
 
 ## 使い方
@@ -60,7 +60,7 @@ mdots --version         # バージョンを表示する（ldflags -X main.versi
 | --- | --- |
 | `push [--target <name>]` | Store から dest へコピーする |
 | `pull [--target <name>]` | dest から Store へ回収する |
-| `diff [--target <name>] [--color auto\|always\|never]` | Storeとdestの差分をStore→dest方向に出力する |
+| `diff [--target <name>] [--color auto\|always\|never]` | Storeとdestの差分をdest→Store方向に出力する |
 | `init` | カレント直下に `mdots.toml` 雛形を作る |
 
 - `--target` 未指定時は common のみ、指定時は common + 指定 Target が対象になる。

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -127,7 +127,7 @@ func (r *runner) newCommand() *cliv3.Command {
 			},
 			{
 				Name:  "diff",
-				Usage: "Storeとdestの差分をStore→dest方向に出力する",
+				Usage: "Storeとdestの差分をdest→Store方向に出力する",
 				Flags: []cliv3.Flag{
 					targetFlag(),
 					colorFlag(),

--- a/cli_test.go
+++ b/cli_test.go
@@ -28,8 +28,8 @@ func TestDiffIntegration(t *testing.T) {
 		if !strings.Contains(out.String(), "---") || !strings.Contains(out.String(), "+++") {
 			t.Errorf("diff output should contain ---/+++, got %q", out.String())
 		}
-		if !strings.Contains(out.String(), "--- vimrc\n") {
-			t.Errorf("diff must be Store->dest fixed, got %q", out.String())
+		if !strings.Contains(out.String(), "+++ vimrc\n") {
+			t.Errorf("diff must be dest->Store fixed, got %q", out.String())
 		}
 		if got, err := os.ReadFile(filepath.Join(home, ".vimrc")); err != nil || string(got) != "old\n" {
 			t.Errorf("dest must NOT be written on diff: content = %q err = %v", got, err)

--- a/config/config.go
+++ b/config/config.go
@@ -159,7 +159,7 @@ const Template = `# mdots.toml — Store（このファイルがあるディレ�
 #   mdots push              # common のみを Store から dest へコピー
 #   mdots push --target win # common + win を対象にする
 #   mdots pull --target win # dest から Store へ回収する
-#   mdots diff              # 差分を Store→dest方向に出力する（差分なし: exit 0、差分あり: exit 1）
+#   mdots diff              # 差分を dest→Store方向に出力する（差分なし: exit 0、差分あり: exit 1）
 #
 # Entry（1つの管理対象）:
 #   src    = Store相対のファイルパス

--- a/docs/adr/0008-revive-diff-remove-dry-run.md
+++ b/docs/adr/0008-revive-diff-remove-dry-run.md
@@ -1,3 +1,3 @@
 # diffコマンドを復活させpush/pull --dry-runを廃止する
 
-0004でdiffを廃止しpush/pull --dry-runに一本化したが、0007でpullのみdest→Storeに反転したため方向で---/+++が入れ替わり混乱するため、差分表示をStore→dest固定の単一diffコマンドに戻すと決めた。欠落は両側とも新規予定として報告し、--target/--colorとexit判定はdry-run資産を引き継ぎ、push/pullの--dry-run/--colorは互換なしで削除する。
+0004でdiffを廃止しpush/pull --dry-runに一本化したが、0007でpullのみdest→Storeに反転したため方向で---/+++が入れ替わり混乱するため、差分表示をdest→Store固定の単一diffコマンドに戻すと決めた。destをold・Storeをnewとするためpushで追加される行が+になり、欠落は両側とも新規予定として報告する。--target/--colorとexit判定はdry-run資産を引き継ぎ、push/pullの--dry-run/--colorは互換なしで削除する。

--- a/sync/diff_test.go
+++ b/sync/diff_test.go
@@ -13,7 +13,7 @@ import (
 // Seam: sync パッケージ公開境界 (diff)
 // 実FS上で書き込みなし・差分出力の外部挙動のみを検証する。
 // Store/dest 準備の定型は sync_test.go のヘルパに集約している。
-func TestDiffShowsStoreToDestFixed(t *testing.T) {
+func TestDiffShowsDestToStoreFixed(t *testing.T) {
 	store, destRoot := setupSyncDirs(t)
 
 	writeTestFile(t, filepath.Join(store, "a"), "new\n")
@@ -28,8 +28,12 @@ func TestDiffShowsStoreToDestFixed(t *testing.T) {
 	if !hasDiff {
 		t.Fatal("hasDiff = false, want true")
 	}
-	if !strings.Contains(out, "--- a\n") || !strings.Contains(out, "+++ "+dest+"\n") {
-		t.Errorf("diff must be Store->dest headers, got %q", out)
+	// old=dest / new=Store: pushで追加される行が+になる
+	if !strings.Contains(out, "--- "+dest+"\n") || !strings.Contains(out, "+++ a\n") {
+		t.Errorf("diff must be dest->Store headers, got %q", out)
+	}
+	if !strings.Contains(out, "+ new") {
+		t.Errorf("Store-side addition must render as +, got %q", out)
 	}
 	if got, _ := os.ReadFile(dest); string(got) != "old\n" {
 		t.Errorf("dest must NOT be written: content = %q", got)

--- a/sync/direction_test.go
+++ b/sync/direction_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Seam: sync パッケージ公開境界 (diff の方向固定)
-// 内容を入れ替えても Store→dest 方向で安定することを検証する。
+// 内容を入れ替えても dest→Store 方向で安定することを検証する。
 func TestDiffDirectionFixed(t *testing.T) {
 	store, destRoot := setupSyncDirs(t)
 
@@ -22,7 +22,7 @@ func TestDiffDirectionFixed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Diff error: %v", err)
 	}
-	if !strings.Contains(out, "--- a\n") || !strings.Contains(out, "+++ "+dest+"\n") {
-		t.Errorf("diff must be Store->dest headers, got %q", out)
+	if !strings.Contains(out, "--- "+dest+"\n") || !strings.Contains(out, "+++ a\n") {
+		t.Errorf("diff must be dest->Store headers, got %q", out)
 	}
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -114,7 +114,8 @@ func diffContent(srcPath, destPath, srcLabel, destLabel string, colorMode string
 	return sb.String(), false, nil
 }
 
-// Diff は Store と dest の差分を Store→dest 方向固定で返す。書き込みは行わない。
+// Diff は Store と dest の差分を dest→Store 方向固定で返す。書き込みは行わない。
+// pushで追加される行が+になるよう dest を old、Store を new とする。
 // 両方存在する Entry は inline diff を出し、片方不在の Entry は新規作成予定として報告する。
 // 両方不在・ディレクトリはエラーで中断する。
 func Diff(storeRoot string, entries []config.Entry) (output string, hasDiff bool, err error) {
@@ -126,7 +127,7 @@ func DiffWithColor(storeRoot string, entries []config.Entry, colorMode string) (
 	return diffUnified(storeRoot, entries, colorMode)
 }
 
-// diffUnified は diff 系の単一の差分コアである。向きは常に Store→dest で固定する。
+// diffUnified は diff 系の単一の差分コアである。向きは常に dest→Store で固定する。
 func diffUnified(storeRoot string, entries []config.Entry, colorMode string) (string, bool, error) {
 	const op = "diff"
 	useColor := resolveUseColor(colorMode)
@@ -155,7 +156,7 @@ func diffUnified(storeRoot string, entries []config.Entry, colorMode string) (st
 			if destInfo.IsDir() {
 				return "", false, fmt.Errorf("%s %s: dest is a directory: %s", op, e.Src, destPath)
 			}
-			writeNewFileNotice(&sb, e.Src, e.Dest, "(new file: "+e.Src+" would be created in Store)\n", useColor)
+			writeNewFileNotice(&sb, e.Dest, e.Src, "(new file: "+e.Src+" would be created in Store)\n", useColor)
 			hasDiff = true
 			continue
 		}
@@ -163,7 +164,7 @@ func diffUnified(storeRoot string, entries []config.Entry, colorMode string) (st
 			if srcInfo.IsDir() {
 				return "", false, fmt.Errorf("%s %s: src is a directory: %s", op, e.Src, srcPath)
 			}
-			writeNewFileNotice(&sb, e.Src, e.Dest, "(new file: "+e.Dest+" would be created)\n", useColor)
+			writeNewFileNotice(&sb, e.Dest, e.Src, "(new file: "+e.Dest+" would be created)\n", useColor)
 			hasDiff = true
 			continue
 		}
@@ -173,7 +174,7 @@ func diffUnified(storeRoot string, entries []config.Entry, colorMode string) (st
 		if destInfo.IsDir() {
 			return "", false, fmt.Errorf("%s %s: dest is a directory: %s", op, e.Src, destPath)
 		}
-		d, same, err := diffContent(srcPath, destPath, e.Src, e.Dest, colorMode)
+		d, same, err := diffContent(destPath, srcPath, e.Dest, e.Src, colorMode)
 		if err != nil {
 			return "", false, fmt.Errorf("%s %s: %w", op, e.Src, err)
 		}


### PR DESCRIPTION
## 背景
#50でdiffに一本化したが、old=Store/new=destだったためpushで追加される行が-側に出て分かりにくいとの指摘。

## 変更
- old=dest/new=Storeに反転。+がpushで追加される行になる
- ヘッダを--- dest/+++ Storeのsrcに統一（新規通知含む）
- テストのヘッダ断定と+/-極性断定を更新（TestDiffShowsDestToStoreFixed、TestDiffDirectionFixed、TestDiffIntegration）
- CONTEXT.md・ADR 0008・README・テンプレ・cli文面をdest→Store固定に更新

## 検証
- go test ./... 全緑、go vet通過